### PR TITLE
Wrong serialization result for rgba/hsla spaces, fixes #296

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -56,7 +56,7 @@ export default function parse (str) {
 				if (format && format.type === "function") {
 					let alpha = 1;
 
-					if (format.lastAlpha || util.last(env.parsed.args).alpha) {
+					if (format.withAlpha || util.last(env.parsed.args).alpha) {
 						alpha = env.parsed.args.pop();
 					}
 

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -2,7 +2,6 @@ import * as util from "./util.js";
 import ColorSpace from "./space.js";
 import defaults from "./defaults.js";
 import getColor from "./getColor.js";
-import to from "./to.js";
 import checkInGamut from "./inGamut.js";
 import toGamut from "./toGamut.js";
 import clone from "./clone.js";
@@ -77,7 +76,9 @@ export default function serialize (color, {
 			alpha = util.toPrecision(alpha, precision);
 		}
 
-		let strAlpha = color.alpha < 1 && !format.noAlpha? `${format.commas? "," : " /"} ${alpha}` : "";
+		let strAlpha = (format.withAlpha || (format.withAlpha === undefined && alpha < 1))
+			? `${format.commas? "," : " /"} ${alpha}`
+			: "";
 		ret = `${name}(${args.join(format.commas? ", " : " ")}${strAlpha})`;
 	}
 

--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -74,7 +74,7 @@ export default new ColorSpace({
 		"hsla": {
 			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
 			commas: true,
-			lastAlpha: true,
+			withAlpha: true,
 		}
 	},
 });

--- a/src/spaces/srgb.js
+++ b/src/spaces/srgb.js
@@ -47,18 +47,19 @@ export default new RGBColorSpace({
 			name: "rgb",
 			commas: true,
 			coords: coordGrammarNumber,
-			noAlpha: true,
+			withAlpha: false,
 		},
 		"color": { /* use defaults */ },
 		"rgba": {
 			coords: coordGrammar,
 			commas: true,
-			lastAlpha: true,
+			withAlpha: true,
 		},
 		"rgba_number": {
 			name: "rgba",
 			commas: true,
-			coords: coordGrammarNumber
+			coords: coordGrammarNumber,
+			withAlpha: true,
 		},
 		"hex": {
 			type: "custom",

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,6 +17,7 @@
 	<ul id="tests">
 		<li><a href="parse.html">Parsing</a></li>
 		<li><a href="construct.html">Object construction</a></li>
+		<li><a href="serialize.html">Serialization</a></li>
 		<li><a href="conversions.html">Conversions</a></li>
 		<li><a href="delta.html">DeltaE</a></li>
 		<li><a href="gamut.html">Gamut mapping</a></li>

--- a/tests/serialize.html
+++ b/tests/serialize.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+<meta charset="UTF-8">
+<title>Color parse tests</title>
+
+<link rel="stylesheet" href="https://htest.dev/htest.css" crossorigin />
+<script src="https://htest.dev/htest.js" crossorigin></script>
+<link rel="stylesheet" href="style.css" />
+
+<script src="../color.js" type="module"></script>
+<script>
+	function serializeTest(format) {
+		let td = document.currentScript.parentNode.previousElementSibling;
+
+		$out(() => {
+			let color = new Color(td.textContent);
+			return color.toString({format});
+		});
+	}
+</script>
+
+</head>
+<body>
+
+<h1>Color serialize Tests</h1>
+<p>These tests serialize different color formats and compare the result as strings.</p>
+
+<section>
+	<h1>sRGB colors</h1>
+	<table class="reftest" data-columns="3" data-colors="1">
+
+		<tr title="format sRGB:rgb">
+			<td>rgb(255 0 120 / 1)</td>
+			<td><script>serializeTest("rgb");</script></td>
+			<td>rgb(100% 0% 47.059%)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / .5)</td>
+			<td><script>serializeTest("rgb");</script></td>
+			<td>rgb(100% 0% 47.059% / 0.5)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / 0)</td>
+			<td><script>serializeTest("rgb");</script></td>
+			<td>rgb(100% 0% 47.059% / 0)</td>
+		</tr>
+
+		<tr title="format sRGB:rgb_number">
+			<td>rgb(255 0 120 / 1)</td>
+			<td><script>serializeTest("rgb_number");</script></td>
+			<td>rgb(255, 0, 120)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / .5)</td>
+			<td><script>serializeTest("rgb_number");</script></td>
+			<td>rgb(255, 0, 120)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / 0)</td>
+			<td><script>serializeTest("rgb_number");</script></td>
+			<td>rgb(255, 0, 120)</td>
+		</tr>
+
+		<tr title="format sRGB:rgba">
+			<td>rgb(255 0 120 / 1)</td>
+			<td><script>serializeTest("rgba");</script></td>
+			<td>rgba(100%, 0%, 47.059%, 1)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / .5)</td>
+			<td><script>serializeTest("rgba");</script></td>
+			<td>rgba(100%, 0%, 47.059%, 0.5)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / 0)</td>
+			<td><script>serializeTest("rgba");</script></td>
+			<td>rgba(100%, 0%, 47.059%, 0)</td>
+		</tr>
+
+		<tr title="format sRGB:rgba_number">
+			<td>rgb(255 0 120 / 1)</td>
+			<td><script>serializeTest("rgba_number");</script></td>
+			<td>rgba(255, 0, 120, 1)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / .5)</td>
+			<td><script>serializeTest("rgba_number");</script></td>
+			<td>rgba(255, 0, 120, 0.5)</td>
+		</tr>
+		<tr>
+			<td>rgb(255 0 120 / 0)</td>
+			<td><script>serializeTest("rgba_number");</script></td>
+			<td>rgba(255, 0, 120, 0)</td>
+		</tr>
+
+		<tr title="format HSL:hsl">
+			<td>hsl(180 50% 50% / 1)</td>
+			<td><script>serializeTest("hsl");</script></td>
+			<td>hsl(180 50% 50%)</td>
+		</tr>
+		<tr>
+			<td>hsl(180 50% 50% / .5)</td>
+			<td><script>serializeTest("hsl");</script></td>
+			<td>hsl(180 50% 50% / 0.5)</td>
+		</tr>
+		<tr>
+			<td>hsl(180 50% 50% / 0)</td>
+			<td><script>serializeTest("hsl");</script></td>
+			<td>hsl(180 50% 50% / 0)</td>
+		</tr>
+
+		<tr title="format HSL:hsla">
+			<td>hsl(180 50% 50% / 1)</td>
+			<td><script>serializeTest("hsla");</script></td>
+			<td>hsla(180, 50%, 50%, 1)</td>
+		</tr>
+		<tr>
+			<td>hsl(180 50% 50% / .5)</td>
+			<td><script>serializeTest("hsla");</script></td>
+			<td>hsla(180, 50%, 50%, 0.5)</td>
+		</tr>
+		<tr>
+			<td>hsl(180 50% 50% / 0)</td>
+			<td><script>serializeTest("hsla");</script></td>
+			<td>hsla(180, 50%, 50%, 0)</td>
+		</tr>
+
+	</table>
+</section>
+
+<script src="index.js" type="module"></script>
+</body>
+</html>

--- a/types/src/space.d.ts
+++ b/types/src/space.d.ts
@@ -12,8 +12,7 @@ export interface Format {
 		| undefined;
 	toGamut?: boolean | undefined;
 	commas?: boolean | undefined;
-	lastAlpha?: boolean | undefined;
-	noAlpha?: boolean | undefined;
+	withAlpha?: boolean | undefined;
 	test?: ((str: string) => boolean) | undefined;
 	parse?: ((str: string) => ColorConstructor) | undefined;
 	serialize?: ((coords: Coords, alpha: number, opts?: Record<string, any>) => string) | undefined;


### PR DESCRIPTION
#296 fix

```js
const c = new Color("rgba(255,0,0,1)");

// before:
c.toString({format: "rgba"}); // rgba(100%, 0%, 0%)
// after:
c.toString({format: "rgba"}); // rgba(100%, 0%, 0%, 1)
```