### PR TITLE
Remove gamut mapping from hsl, hwb and hsv

### DIFF
--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -68,7 +68,6 @@ export default new ColorSpace({
 
 	formats: {
 		"hsl": {
-			toGamut: true,
 			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
 		},
 		"hsla": {

--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -54,10 +54,5 @@ export default new ColorSpace({
 			(l === 0 || l === 1)? 0 : ((v - l) / Math.min(l, 1 - l)) * 100,
 			l * 100
 		];
-	},
-	formats: {
-		color: {
-			toGamut: true,
-		}
 	}
 });

--- a/src/spaces/hwb.js
+++ b/src/spaces/hwb.js
@@ -52,7 +52,6 @@ export default new ColorSpace({
 
 	formats: {
 		"hwb": {
-			toGamut: true,
 			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
 		}
 	}

--- a/tests/conversions.html
+++ b/tests/conversions.html
@@ -36,6 +36,7 @@ let convertToRec2020 = convertTo("rec2020");
 let convertToOK = convertTo("oklab");
 let convertToOKLCh = convertTo("oklch");
 let convertTosrgbLin = convertTo("srgb-linear");
+let convertToHSV = convertTo("hsv");
 
 </script>
 
@@ -172,6 +173,39 @@ let convertTosrgbLin = convertTo("srgb-linear");
 				</script>
 			</td>
 			<td>NaN, 100, 0</td>
+		</tr>
+	</table>
+</section>
+
+<section>
+	<h1>Out of RGB gamut conversions</h1>
+	<table class="reftest" data-test="numbers" data-columns="3" data-colors="1">
+		<tr title="HWB">
+			<td>color(rec2020 0 0 1)</td>
+			<td>
+				<script>
+					convertToHWB();
+				</script>
+			</td>
+			<td>230.639, -29.921, -5.0489</td>
+		</tr>
+		<tr title="HSL">
+			<td>color(rec2020 0 0 1)</td>
+			<td>
+				<script>
+					convertToHSL();
+				</script>
+			</td>
+			<td>230.639, 179.655, 37.564</td>
+		</tr>
+		<tr title="HSV">
+			<td>color(rec2020 0 0 1)</td>
+			<td>
+				<script>
+					convertToHSV();
+				</script>
+			</td>
+			<td>230.639, 128.483, 105.0489</td>
 		</tr>
 	</table>
 </section>

--- a/tests/parse.html
+++ b/tests/parse.html
@@ -351,8 +351,8 @@
 			<td>{"spaceId":"hsl","coords":[NaN,0,0],"alpha":0.5}</td>
 		</tr>
 		<tr title="hsla(), oog color(rec2020 0 0 1)">
-			<td>hsl(90deg 0% 0% / .5)</td>
-			<td>{"spaceId":"hsl","coords":[90,0,0],"alpha":0.5}</td>
+			<td>hsl(230.6 179.7% 37.56% / 1)</td>
+			<td>{"spaceId":"hsl","coords":[230.6,179.7,37.56],"alpha":1}</td>
 		</tr>
 		<tr title="hsl(), none hue ">
 			<td>hsl(none, 50%, 50%)</td>


### PR DESCRIPTION
This PR addresses https://github.com/LeaVerou/color.js/issues/325.

The issue doesn't mention hsv, but since it's based on hsl, I removed gamut mapping from there as well. This essentially is reverting 960b4ab878d0e1a8b31726df2a4805e3b5148ad6.