### PR TITLE
Add color spaces for Luv, LCHuv, HSLuv and HPLuv.

### DIFF
--- a/get/modules.json
+++ b/get/modules.json
@@ -153,6 +153,33 @@
 			"id": "acescg",
 			"url": "https://en.wikipedia.org/wiki/Academy_Color_Encoding_System",
 			"description": "Scene-referred Academy Color Encoding System, using the wide gamut but physically realizable AP1 primaries and linear-light encoding. Used for physical rendering."
+		},
+		{
+			"name": "Luv",
+			"id": "luv",
+			"url": "https://en.wikipedia.org/wiki/CIELUV",
+			"description": ""
+		},
+		{
+			"name": "LCHuv",
+			"id": "lchuv",
+			"dependencies": ["luv"],
+			"url": "https://en.wikipedia.org/wiki/CIELUV",
+			"description": "The polar (Hue, Chroma) form of CIE Luv."
+		},
+		{
+			"name": "HSLuv",
+			"id": "hsluv",
+			"dependencies": ["lchuv"],
+			"url": "https://www.hsluv.org/comparison/",
+			"description": "The HSLuv color space is a perceptually uniform adaptation of the traditional HSL (Hue, Saturation, Lightness) color model. Engineered upon the foundations of the CIELUV color space, HSLuv ensures that colors that appear equally spaced in its representation also present consistent perceptual differences to the human observer. This results in a color space where changes in hue, saturation, or lightness produce predictable and coherent visual outcomes, addressing inconsistencies and unpredictable color shifts often found in standard HSL."
+		},
+		{
+			"name": "HPLuv",
+			"id": "hpluv",
+			"dependencies": ["lchuv"],
+			"url": "https://www.hsluv.org/comparison/",
+			"description": "The HPLuv color space emphasizes perceptual uniformity specifically in its lightness component. HPLuv ensures that changes in lightness are consistently perceived by the human eye, regardless of the hue or saturation of the color. The resulting palette is a subset of sRGB and the colors are mainly pastel."
 		}
 	],
 	"optional": [

--- a/src/space.js
+++ b/src/space.js
@@ -19,6 +19,15 @@ export default class ColorSpace {
 			this.toBase = options.toBase;
 		}
 
+		if (options.gamutCheck)	{
+			if (options.gamutCheck === "self") {
+				this.gamutCheck = this;
+			}
+			else {
+				this.gamutCheck = ColorSpace.get(options.gamutCheck);
+			}
+		}
+
 		// Coordinate metadata
 
 		let coords = options.coords ?? this.base.coords;
@@ -68,8 +77,17 @@ export default class ColorSpace {
 	}
 
 	inGamut (coords, {epsilon = ε} = {}) {
-		if (this.isPolar) {
+		// If the gamutCheck space is specified and not ourself then
+		// use the gamutCheck space to check if the coords are in gamut
+		if (this.gamutCheck && !this.equals(this.gamutCheck)) {
+			coords = this.to(this.gamutCheck, coords);
+			return this.gamutCheck.inGamut(coords, {epsilon});
+		}
+
+		if (this.isPolar && !this.equals(this.gamutCheck)) {
 			// Do not check gamut through polar coordinates
+			// unless this space is the gamutCheck space
+
 			coords = this.toBase(coords);
 
 			return this.base.inGamut(coords, {epsilon});

--- a/src/spaces/hpluv.js
+++ b/src/spaces/hpluv.js
@@ -1,0 +1,129 @@
+/*
+Adapted from: https://github.com/hsluv/hsluv-javascript/blob/14b49e6cf9a9137916096b8487a5372626b57ba4/src/hsluv.ts
+
+Copyright (c) 2012-2022 Alexei Boronine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import ColorSpace from "../space.js";
+import LCHuv from "./lchuv.js";
+import {fromXYZ_M} from "./srgb-linear.js";
+import {calculateBoundingLines} from "./hsluv.js";
+
+const ε = 216/24389;  // 6^3/29^3 == (24/116)^3
+const κ = 24389/27;   // 29^3/3^3
+
+const m_r0 = fromXYZ_M[0][0];
+const m_r1 = fromXYZ_M[0][1];
+const m_r2 = fromXYZ_M[0][2];
+const m_g0 = fromXYZ_M[1][0];
+const m_g1 = fromXYZ_M[1][1];
+const m_g2 = fromXYZ_M[1][2];
+const m_b0 = fromXYZ_M[2][0];
+const m_b1 = fromXYZ_M[2][1];
+const m_b2 = fromXYZ_M[2][2];
+
+function distanceFromOrigin (slope, intercept) {
+	return Math.abs(intercept) / Math.sqrt(Math.pow(slope, 2) + 1);
+}
+
+function calcMaxChromaHpluv (lines) {
+	let r0 = distanceFromOrigin(lines.r0s, lines.r0i);
+	let r1 = distanceFromOrigin(lines.r1s, lines.r1i);
+	let g0 = distanceFromOrigin(lines.g0s, lines.g0i);
+	let g1 = distanceFromOrigin(lines.g1s, lines.g1i);
+	let b0 = distanceFromOrigin(lines.b0s, lines.b0i);
+	let b1 = distanceFromOrigin(lines.b1s, lines.b1i);
+
+	return Math.min(r0, r1, g0, g1, b0, b1);
+}
+
+export default new ColorSpace({
+	id: "hpluv",
+	name: "HPLuv",
+	coords: {
+		h: {
+			refRange: [0, 360],
+			type: "angle",
+			name: "Hue"
+		},
+		s: {
+			range: [0, 100],
+			name: "Saturation"
+		},
+		l: {
+			range: [0, 100],
+			name: "Lightness"
+		}
+	},
+
+	base: LCHuv,
+	gamutCheck: "self",
+
+	// Convert LCHuv to HPLuv
+	fromBase (lch) {
+		let [L, c, h] = lch;
+		let s, l;
+
+        if (L > 99.9999999) {
+            s = 0;
+            l = 100;
+        }
+		else if (L < 0.00000001) {
+            s = 0;
+            l = 0;
+        }
+		else {
+            let lines = calculateBoundingLines(L);
+            let max = calcMaxChromaHpluv(lines);
+            s = c / max * 100;
+            l = L;
+        }
+		return [h, s, l];
+	},
+
+	// Convert HPLuv to LCHuv
+	toBase (hsl) {
+		let [h, s, l] = hsl;
+		let L, c;
+        if (l > 99.9999999) {
+            L = 100;
+            c = 0;
+        }
+		else if (l < 0.00000001) {
+            L = 0;
+            c = 0;
+        }
+		else {
+            L = l;
+			let lines = calculateBoundingLines(L);
+			let max = calcMaxChromaHpluv(lines, h);
+			c = max / 100 * s;
+        }
+		return [L, c, h];
+	},
+
+	formats: {
+		color: {
+			id: "--hpluv",
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"]
+		}
+	},
+});

--- a/src/spaces/hsluv.js
+++ b/src/spaces/hsluv.js
@@ -1,0 +1,160 @@
+/*
+Adapted from: https://github.com/hsluv/hsluv-javascript/blob/14b49e6cf9a9137916096b8487a5372626b57ba4/src/hsluv.ts
+
+Copyright (c) 2012-2022 Alexei Boronine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import ColorSpace from "../space.js";
+import LCHuv from "./lchuv.js";
+import sRGB from "./srgb.js";
+import { fromXYZ_M } from "./srgb-linear.js";
+
+const ε = 216/24389;  // 6^3/29^3 == (24/116)^3
+const κ = 24389/27;   // 29^3/3^3
+
+const m_r0 = fromXYZ_M[0][0];
+const m_r1 = fromXYZ_M[0][1];
+const m_r2 = fromXYZ_M[0][2];
+const m_g0 = fromXYZ_M[1][0];
+const m_g1 = fromXYZ_M[1][1];
+const m_g2 = fromXYZ_M[1][2];
+const m_b0 = fromXYZ_M[2][0];
+const m_b1 = fromXYZ_M[2][1];
+const m_b2 = fromXYZ_M[2][2];
+
+function distanceFromOriginAngle (slope, intercept, angle) {
+	const d = intercept / (Math.sin(angle) - slope * Math.cos(angle));
+	return d < 0 ? Infinity : d;
+}
+
+export function calculateBoundingLines (l) {
+	const sub1 = Math.pow(l + 16, 3) / 1560896;
+	const sub2 = sub1 > ε ? sub1 : l / κ;
+	const s1r = sub2 * (284517 * m_r0 - 94839 * m_r2);
+	const s2r = sub2 * (838422 * m_r2 + 769860 * m_r1 + 731718 * m_r0);
+	const s3r = sub2 * (632260 * m_r2 - 126452 * m_r1);
+	const s1g = sub2 * (284517 * m_g0 - 94839 * m_g2);
+	const s2g = sub2 * (838422 * m_g2 + 769860 * m_g1 + 731718 * m_g0);
+	const s3g = sub2 * (632260 * m_g2 - 126452 * m_g1);
+	const s1b = sub2 * (284517 * m_b0 - 94839 * m_b2);
+	const s2b = sub2 * (838422 * m_b2 + 769860 * m_b1 + 731718 * m_b0);
+	const s3b = sub2 * (632260 * m_b2 - 126452 * m_b1);
+
+	return {
+		r0s: s1r / s3r,
+		r0i: s2r * l / s3r,
+		r1s: s1r / (s3r + 126452),
+		r1i: (s2r - 769860) * l / (s3r + 126452),
+		g0s: s1g / s3g,
+		g0i: s2g * l / s3g,
+		g1s: s1g / (s3g + 126452),
+		g1i: (s2g - 769860) * l / (s3g + 126452),
+		b0s: s1b / s3b,
+		b0i: s2b * l / s3b,
+		b1s: s1b / (s3b + 126452),
+		b1i: (s2b - 769860) * l / (s3b + 126452)
+	};
+}
+
+function calcMaxChromaHsluv (lines, h) {
+	const hueRad = h / 360 * Math.PI * 2;
+	const r0 = distanceFromOriginAngle(lines.r0s, lines.r0i, hueRad);
+	const r1 = distanceFromOriginAngle(lines.r1s, lines.r1i, hueRad);
+	const g0 = distanceFromOriginAngle(lines.g0s, lines.g0i, hueRad);
+	const g1 = distanceFromOriginAngle(lines.g1s, lines.g1i, hueRad);
+	const b0 = distanceFromOriginAngle(lines.b0s, lines.b0i, hueRad);
+	const b1 = distanceFromOriginAngle(lines.b1s, lines.b1i, hueRad);
+
+	return Math.min(r0, r1, g0, g1, b0, b1);
+}
+
+export default new ColorSpace({
+	id: "hsluv",
+	name: "HSLuv",
+	coords: {
+		h: {
+			refRange: [0, 360],
+			type: "angle",
+			name: "Hue"
+		},
+		s: {
+			refRange: [0, 100],
+			name: "Saturation"
+		},
+		l: {
+			refRange: [0, 100],
+			name: "Lightness"
+		}
+	},
+
+	base: LCHuv,
+	gamutCheck: sRGB,
+
+	// Convert LCHuv to HSLuv
+	fromBase (lch) {
+		let [L, c, h] = lch;
+		let s, l;
+
+        if (L > 99.9999999) {
+            s = 0;
+            l = 100;
+        }
+		else if (L < 0.00000001) {
+            s = 0;
+            l = 0;
+        }
+		else {
+            let lines = calculateBoundingLines(L);
+            let max = calcMaxChromaHsluv(lines, h);
+            s = c / max * 100;
+            l = L;
+        }
+		return [h, s, l];
+	},
+
+	// Convert HSLuv to LCHuv
+	toBase (hsl) {
+		let [h, s, l] = hsl;
+		let L, c;
+        if (l > 99.9999999) {
+            L = 100;
+            c = 0;
+        }
+		else if (l < 0.00000001) {
+            L = 0;
+            c = 0;
+        }
+		else {
+            L = l;
+			let lines = calculateBoundingLines(L);
+			let max = calcMaxChromaHsluv(lines, h);
+			c = max / 100 * s;
+        }
+		return [L, c, h];
+	},
+
+	formats: {
+		color: {
+			id: "--hsluv",
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"]
+		}
+	},
+});

--- a/src/spaces/index-fn.js
+++ b/src/spaces/index-fn.js
@@ -19,5 +19,9 @@ export {default as REC_2020_Linear} from "./rec2020-linear.js";
 export {default as REC_2020} from "./rec2020.js";
 export {default as OKLab} from "./oklab.js";
 export {default as OKLCH} from "./oklch.js";
+export {default as Luv} from "./luv.js";
+export {default as LCHuv} from "./lchuv.js";
+export {default as HSLuv} from "./hsluv.js";
+export {default as HPLuv} from "./hpluv.js";
 
 export * from "./index-fn-hdr.js";

--- a/src/spaces/lchuv.js
+++ b/src/spaces/lchuv.js
@@ -1,0 +1,68 @@
+import ColorSpace from "../space.js";
+import Luv from "./luv.js";
+import {constrain as constrainAngle} from "../angles.js";
+
+export default new ColorSpace({
+	id: "lchuv",
+	name: "LChuv",
+	coords: {
+		l: {
+			refRange: [0, 100],
+			name: "Lightness"
+		},
+		c: {
+			refRange: [0, 220],
+			name: "Chroma"
+		},
+		h: {
+			refRange: [0, 360],
+			type: "angle",
+			name: "Hue"
+		}
+	},
+
+	base: Luv,
+	fromBase (Luv) {
+		// Convert to polar form
+		let [L, u, v] = Luv;
+		let hue;
+		const ε = 0.02;
+
+		if (Math.abs(u) < ε && Math.abs(v) < ε) {
+			hue = NaN;
+		}
+		else {
+			hue = Math.atan2(v, u) * 180 / Math.PI;
+		}
+
+		return [
+			L, // L is still L
+			Math.sqrt(u ** 2 + v ** 2), // Chroma
+			constrainAngle(hue) // Hue, in degrees [0 to 360)
+		];
+	},
+	toBase (LCH) {
+		// Convert from polar form
+		let [Lightness, Chroma, Hue] = LCH;
+		// Clamp any negative Chroma
+		if (Chroma < 0) {
+			Chroma = 0;
+		};
+		// Deal with NaN Hue
+		if (isNaN(Hue)) {
+			Hue = 0;
+		}
+		return [
+			Lightness, // L is still L
+			Chroma * Math.cos(Hue * Math.PI / 180), // u
+			Chroma * Math.sin(Hue * Math.PI / 180)  // v
+		];
+	},
+
+	formats: {
+		color: {
+			id: "--lchuv",
+			coords: ["<number> | <percentage>", "<number> | <percentage>", "<number> | <angle>"],
+		}
+	}
+});

--- a/src/spaces/luv.js
+++ b/src/spaces/luv.js
@@ -1,0 +1,80 @@
+import ColorSpace from "../space.js";
+import {WHITES} from "../adapt.js";
+import xyz_d65 from "./xyz-d65.js";
+import {uv} from "../chromaticity.js";
+
+let white = WHITES.D65;
+
+const ε = 216/24389;  // 6^3/29^3 == (24/116)^3
+const κ = 24389/27;   // 29^3/3^3
+const [U_PRIME_WHITE, V_PRIME_WHITE] = uv({space: xyz_d65, coords: white});
+
+export default new ColorSpace({
+	id: "luv",
+	name: "Luv",
+	coords: {
+		l: {
+			refRange: [0, 100],
+			name: "L"
+		},
+		// Reference ranges from https://facelessuser.github.io/coloraide/colors/luv/
+		u: {
+			refRange: [-215, 215]
+		},
+		v: {
+			refRange: [-215, 215]
+		}
+	},
+
+	white: white,
+	base: xyz_d65,
+
+	// Convert D65-adapted XYZ to Luv
+	// https://en.wikipedia.org/wiki/CIELUV#The_forward_transformation
+	fromBase (XYZ) {
+		let y = XYZ[1];
+
+		let [up, vp] = uv({space: xyz_d65, coords: XYZ});
+
+		// Protect against XYZ of [0, 0, 0]
+		if (!Number.isFinite(up) || !Number.isFinite(vp)) {
+			return [0, 0, 0];
+		}
+
+		let L = y <= ε ? κ * y : 116 * Math.cbrt(y) - 16;
+
+		return [
+			L,
+			13 * L * (up - U_PRIME_WHITE),
+			13 * L * (vp - V_PRIME_WHITE)
+		 ];
+	},
+
+	// Convert Luv to D65-adapted XYZ
+	// https://en.wikipedia.org/wiki/CIELUV#The_reverse_transformation
+	toBase (Luv) {
+		let [L, u, v] = Luv;
+
+		// Protect against division by zero
+		if (L == 0) {
+			return [0, 0, 0];
+		}
+
+		let up = (u / (13 * L)) + U_PRIME_WHITE;
+		let vp = (v / (13 * L)) + V_PRIME_WHITE;
+
+		let y = L <= 8 ? L / κ : Math.pow((L + 16) / 116, 3);
+
+		return [
+			y * ((9 * up) / (4 * vp)),
+			y,
+			y * ((12 - 3 * up - 20 * vp) / (4 * vp))
+		];
+	},
+
+	formats: {
+		color: {
+			id: "--luv",
+			coords: ["<number> | <percentage>", "<number> | <percentage>[-1,1]", "<number> | <percentage>[-1,1]"]		}
+	},
+});

--- a/src/spaces/srgb-linear.js
+++ b/src/spaces/srgb-linear.js
@@ -15,7 +15,7 @@ const toXYZ_M = [
 
 // This matrix is the inverse of the above;
 // again it agrees with the official definition when rounded to 8 decimal places
-const fromXYZ_M = [
+export const fromXYZ_M = [
 	[  3.2409699419045226,  -1.537383177570094,   -0.4986107602930034  ],
 	[ -0.9692436362808796,   1.8759675015077202,   0.04155505740717559 ],
 	[  0.05563007969699366, -0.20397695888897652,  1.0569715142428786  ]

--- a/tests/conversions.html
+++ b/tests/conversions.html
@@ -37,6 +37,9 @@ let convertToOK = convertTo("oklab");
 let convertToOKLCh = convertTo("oklch");
 let convertTosrgbLin = convertTo("srgb-linear");
 let convertToHSV = convertTo("hsv");
+let convertToLuv = convertTo("luv");
+let convertToHSLuv = convertTo("hsluv");
+let convertToHPLuv = convertTo("hpluv");
 
 </script>
 
@@ -1019,6 +1022,245 @@ let convertToHSV = convertTo("hsv");
 		</tr>
 	</table>
 </section>
+
+<section>
+	<h1>Luv to (D65) XYZ and Back</h1>
+	<table class="reftest" data-test="numbers" data-columns="3" data-colors="1">
+		<tr title="XYZ-D65 to Luv">
+			<td>color(xyz-d65 0.41239 0.21264 0.01933)</td>
+			<td>
+				<script>
+					convertToLuv();
+				</script>
+			</td>
+			<td>53.23722349423123, 175.00857887972651, 37.765709486538924</td>
+		</tr>
+		<tr title="XYZ-D65 (black) to Luv">
+			<td>color(xyz-d65 0 0 0)</td>
+			<td>
+				<script>
+					convertToLuv();
+				</script>
+			</td>
+			<td>0, 0, 0</td>
+		</tr>
+		<tr title="XYZ-D65 (D65 white) to Luv">
+			<td>color(xyz-d65 0.95045592705 1 1.08905775076)</td>
+			<td>
+				<script>
+					convertToLuv();
+				</script>
+			</td>
+			<td>100, 0, 0</td>
+		</tr>
+		<tr title="XYZ-D65 (slategray) to Luv">
+			<td>color(xyz-d65 0.186455 0.19935 0.284575)</td>
+			<td>
+				<script>
+					convertToLuv();
+				</script>
+			</td>
+			<td>51.763618682080377, -8.6016481223411709, -15.591207397376769</td>
+		</tr>
+		<tr title="Luv to XYZ-D65">
+			<td>color(--luv 53.23722349423123 175.00857887972651 37.765709486538924)</td>
+			<td>
+				<script>
+					convertToXYZ();
+				</script>
+			</td>
+			<td>0.41239, 0.21264, 0.01933</td>
+		</tr>
+		<tr title="Luv (black) to XYZ-D65">
+			<td>color(--luv 0 0 0)</td>
+			<td>
+				<script>
+					convertToXYZ();
+				</script>
+			</td>
+			<td>0, 0, 0</td>
+		</tr>
+		<tr title="Luv (white) to XYZ-D65">
+			<td>color(--luv 100 0 0)</td>
+			<td>
+				<script>
+					convertToXYZ();
+				</script>
+			</td>
+			<td>0.95045592705, 1, 1.08905775076</td>
+		</tr>
+		<tr title="Luv (slategray) to XYZ-D65">
+			<td>color(--luv 51.763618682080377 -8.6016481223411709 -15.591207397376769)</td>
+			<td>
+				<script>
+					convertToXYZ();
+				</script>
+			</td>
+			<td>0.186455, 0.19935, 0.284575</td>
+		</tr>
+	</table>
+</section>
+
+<section>
+	<h1>HSLuv to RGB and back</h1>
+	<p>Conversions tested against results from <a href="https://github.com/hsluv/hsluv/blob/c6227fb52a095cd0f93ab5e985600bc1ceed4f1c/snapshots/snapshot-rev4.json">published test data</a></p>
+	<table class="reftest" data-test="numbers" data-columns="3" data-colors="1">
+		<tr>
+			<td>color(--hsluv 127.478988192005161, 100, 82.5213119008325577)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.0666666666666666657, 0.933333333333333348, 0</td>
+		</tr>
+		<tr>
+			<td>color(--hsluv 206.653495587531239, 100, 69.3970058395379397)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0, 0.733333333333333282, 0.8</td>
+		</tr>
+		<tr>
+			<td>color(--hsluv 265.874320218178866 221.531011478982748 47.8629477245616854)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.4,0.4,0.8</td>
+		</tr>
+		<tr>
+			<td>color(--hsluv 215.786316478612605 162.428807277722512 81.3185562290371848)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.0666666666666666657, 0.866666666666666696, 1</td>
+		</tr>
+		<tr>
+			<td>#11ee00</td>
+			<td>
+				<script>
+					convertToHSLuv();
+				</script>
+			</td>
+			<td>127.478988192005161, 100.000000000002416, 82.5213119008325577</td>
+		</tr>
+		<tr>
+			<td>#00bbcc</td>
+			<td>
+				<script>
+					convertToHSLuv();
+				</script>
+			</td>
+			<td>206.653495587531239, 99.9999999999915161, 69.3970058395379397</td>
+		</tr>
+		<tr>
+			<td>#6666cc</td>
+			<td>
+				<script>
+					convertToHSLuv();
+				</script>
+			</td>
+			<td>265.874320218178866, 66.0482344892977693, 47.8629477245616854</td>
+		</tr>
+		<tr>
+			<td>#11ddff</td>
+			<td>
+				<script>
+					convertToHSLuv();
+				</script>
+			</td>
+			<td>215.786316478612605, 99.9999999999959925, 81.3185562290371848</td>
+		</tr>
+	</table>
+</section>
+
+<section>
+	<h1>HPLuv to RGB and back</h1>
+	<p>Conversions tested against results from <a href="https://github.com/hsluv/hsluv/blob/c6227fb52a095cd0f93ab5e985600bc1ceed4f1c/snapshots/snapshot-rev4.json">published test data</a></p>
+	<table class="reftest" data-test="numbers" data-columns="3" data-colors="1">
+		<tr>
+			<td>color(--hpluv 127.478988192005161 308.195222762673438 82.5213119008325577)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.0666666666666666657, 0.933333333333333348, 0</td>
+		</tr>
+		<tr>
+			<td>color(--hpluv 206.653495587531239 106.116119046155191 69.3970058395379397)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0, 0.733333333333333282, 0.8</td>
+		</tr>
+		<tr>
+			<td>color(--hpluv 265.874320218178866 221.531011478982748 47.8629477245616854)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.4,0.4,0.8</td>
+		</tr>
+		<tr>
+			<td>color(--hpluv 215.786316478612605 162.428807277722512 81.3185562290371848)</td>
+			<td>
+				<script>
+					convertToSRGB();
+				</script>
+			</td>
+			<td>0.0666666666666666657, 0.866666666666666696, 1</td>
+		</tr>
+		<tr>
+			<td>#11ee00</td>
+			<td>
+				<script>
+					convertToHPLuv();
+				</script>
+			</td>
+			<td>127.478988192005161, 308.195222762673438, 82.5213119008325577</td>
+		</tr>
+		<tr>
+			<td>#00bbcc</td>
+			<td>
+				<script>
+					convertToHPLuv();
+				</script>
+			</td>
+			<td>206.653495587531239, 106.116119046155191, 69.3970058395379397</td>
+		</tr>
+		<tr>
+			<td>#6666cc</td>
+			<td>
+				<script>
+					convertToHPLuv();
+				</script>
+			</td>
+			<td>265.874320218178866, 221.531011478982748, 47.8629477245616854</td>
+		</tr>
+		<tr>
+			<td>#11ddff</td>
+			<td>
+				<script>
+					convertToHPLuv();
+				</script>
+			</td>
+			<td>215.786316478612605, 162.428807277722512, 81.3185562290371848</td>
+		</tr>
+	</table>
+</section>
+
+
+
 
 <script src="index.js" type="module"></script>
 </body>

--- a/tests/parse.html
+++ b/tests/parse.html
@@ -283,6 +283,46 @@
 			<td>color(xyz-d50 0 100% 50%)</td>
 			<td>{"spaceId":"xyz-d50","coords":[0,1,0.5],"alpha":1}</td>
 		</tr>
+		<tr title="luv">
+			<td>color(--luv 100% 0 0)</td>
+			<td>{"spaceId":"luv","coords":[100,0,0],"alpha":1}</td>
+		</tr>
+		<tr title="luv - no percent">
+			<td>color(--luv 80 0 0)</td>
+			<td>{"spaceId":"luv","coords":[80,0,0],"alpha":1}</td>
+		</tr>
+		<tr>
+			<td>color(--luv 100 -50 50)</td>
+			<td>{"spaceId":"luv","coords":[100,-50,50],"alpha":1}</td>
+		</tr>
+		<tr title="luv percentage">
+			<td>color(--luv 50% 25% -25% / 50%)</td>
+			<td>{"spaceId":"luv","coords":[50,53.75,-53.75],"alpha":0.5}</td>
+		</tr>
+		<tr title="luv transparency">
+			<td>color(--luv 100 -50 5 / .5)</td>
+			<td>{"spaceId":"luv","coords":[100,-50,5],"alpha":0.5}</td>
+		</tr>
+		<tr title="lchuv">
+			<td>color(--lchuv 100% 0 0)</td>
+			<td>{"spaceId":"lchuv","coords":[100,0,0],"alpha":1}</td>
+		</tr>
+		<tr title="lchuv no percentage">
+			<td>color(--lchuv 100 50 50)</td>
+			<td>{"spaceId":"lchuv","coords":[100,50,50],"alpha":1}</td>
+		</tr>
+		<tr title="lchuv percentage">
+			<td>color(--lchuv 50% 50% 50 / 50%)</td>
+			<td>{"spaceId":"lchuv","coords":[50,110,50],"alpha":0.5}</td>
+		</tr>
+		<tr title="lchuv Hue over 360">
+			<td>color(--lchuv 100 50 450)</td>
+			<td>{"spaceId":"lchuv","coords":[100,50,450],"alpha":1}</td>
+		</tr>
+		<tr title="lchuv none hue">
+			<td>color(--lchuv 100 0 none)</td>
+			<td>{"spaceId":"lchuv","coords":[100,00,NaN],"alpha":1}</td>
+		</tr>
 		<tr title="With transparency">
 			<td>color(display-p3 0 1 0 / .5)</td>
 			<td>{"spaceId":"p3","coords":[0,1,0],"alpha":0.5}</td>
@@ -310,7 +350,6 @@
 			<td>color(display-p3 none 1 .5)</td>
 			<td>{"spaceId":"p3","coords":[NaN,1,0.5],"alpha":1}</td>
 		</tr>
-
 	</table>
 </section>
 

--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -146,7 +146,9 @@ declare class Color implements PlainColorObject {
 	a98rgb_linear: SpaceAccessor;
 	acescc: SpaceAccessor;
 	acescg: SpaceAccessor;
+	hpluv: SpaceAccessor;
 	hsl: SpaceAccessor;
+	hsluv: SpaceAccessor;
 	hsv: SpaceAccessor;
 	hwb: SpaceAccessor;
 	ictcp: SpaceAccessor;
@@ -155,6 +157,8 @@ declare class Color implements PlainColorObject {
 	lab: SpaceAccessor;
 	lab_d65: SpaceAccessor;
 	lch: SpaceAccessor;
+	lchuv: SpaceAccessor;
+	luv: SpaceAccessor;
 	oklab: SpaceAccessor;
 	oklch: SpaceAccessor;
 	p3: SpaceAccessor;

--- a/types/src/space.d.ts
+++ b/types/src/space.d.ts
@@ -37,6 +37,7 @@ export interface Options {
 	cssId?: string | undefined;
 	referred?: string | undefined;
 	formats?: Record<string, Format> | undefined;
+	gamutCheck?: string | ColorSpace | null | undefined;
 }
 
 export type Ref =

--- a/types/src/spaces/hpluv.d.ts
+++ b/types/src/spaces/hpluv.d.ts
@@ -1,0 +1,3 @@
+import ColorSpace from "../space.js";
+declare const _default: ColorSpace;
+export default _default;

--- a/types/src/spaces/hsluv.d.ts
+++ b/types/src/spaces/hsluv.d.ts
@@ -1,0 +1,3 @@
+import ColorSpace from "../space.js";
+declare const _default: ColorSpace;
+export default _default;

--- a/types/src/spaces/index-fn.d.ts
+++ b/types/src/spaces/index-fn.d.ts
@@ -21,5 +21,9 @@ export { default as REC_2020_Linear } from "./rec2020-linear.js";
 export { default as REC_2020 } from "./rec2020.js";
 export { default as OKLab } from "./oklab.js";
 export { default as OKLCH } from "./oklch.js";
+export { default as Luv } from "./luv";
+export { default as LCHuv } from "./lchuv";
+export { default as HSLuv } from "./hsluv";
+export { default as HPLuv } from "./hpluv";
 
 export * from "./index-fn-hdr.js";

--- a/types/src/spaces/lchuv.d.ts
+++ b/types/src/spaces/lchuv.d.ts
@@ -1,0 +1,3 @@
+import ColorSpace from "../space.js";
+declare const _default: ColorSpace;
+export default _default;

--- a/types/src/spaces/luv.d.ts
+++ b/types/src/spaces/luv.d.ts
@@ -1,0 +1,3 @@
+import ColorSpace from "../space.js";
+declare const _default: ColorSpace;
+export default _default;


### PR DESCRIPTION
This is a draft PR for adding the [Luv, LCHuv](https://en.wikipedia.org/wiki/CIELUV), [HSLuv and HPLuv](https://www.hsluv.org/) color spaces.

It's probably to big for single commit so I plan on breaking it up into four smaller pull requests after it has been reviewed:

1. Allow color spaces that are parsed and serialized using the color() function to have a coord grammer.
2. Allow color spaces to specify which color space to use when checking to see if a color is inGamut.
3. Luv and LCHuv color spaces
4. HSLuv and HPLuv color spaces

The Javascript reference implementation for HSLuv and HPLuv can be found [here](https://github.com/hsluv/hsluv-javascript/blob/14b49e6cf9a9137916096b8487a5372626b57ba4/src/hsluv.ts). The HSLuv and HPLuv color spaces are based on the reference implementation so I've add the license file from that repository to the source code for those two color spaces. I'm assuming that's ok.

**Gamut Checking**

I wasn't sure how to do gamut checking for HSLuv and HPLuv. The `ColorSpace` `inGamut` function uses the base space if the current space is a polar space. This doesn't work for HSLuv and HPLuv because the base space has a larger gamut.

I added a new property to the `ColorSpace` class called `gamutCheck` which is either a color space that should be used for gamut checking (sRGB in the case of HSLuv) or `"self"` which means use the current color space for gamut checking. HPLuv uses `"self"` because it has a gamut that is a subset of sRGB.
