### PR TITLE
Fix node 16 module resolution for CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,29 @@
 		"src/",
 		"types/dist/",
 		"types/src/",
-		"types/index.d.ts"
+		"types/index.d.ts",
+		"types/index.d.cts"
 	],
 	"exports": {
 		".": {
-			"types": "./types/index.d.ts",
-			"import": "./dist/color.js",
-			"require": "./dist/color.cjs"
+			"import": {
+				"default": "./dist/color.js",
+				"types": "./types/index.d.ts"
+			},
+			"require": {
+				"default": "./dist/color.cjs",
+				"types": "./types/index.d.cts"
+			}
 		},
 		"./fn": {
-			"types": "./types/src/index-fn.d.ts",
-			"import": "./src/index-fn.js",
-			"require": "./dist/color-fn.cjs"
+			"import": {
+				"default": "./src/index-fn.js",
+				"types": "./types/src/index-fn.d.ts"
+			},
+			"require": {
+				"default": "./dist/color-fn.cjs",
+				"types": "./types/src/index-fn.d.cts"
+			}
 		},
 		"./dist/*": "./dist/*"
 	},

--- a/types/index.d.cts
+++ b/types/index.d.cts
@@ -1,0 +1,2 @@
+export { default } from "./index.js";
+export * from "./index.js";

--- a/types/src/index-fn.d.cts
+++ b/types/src/index-fn.d.cts
@@ -1,0 +1,1 @@
+export * from "./index-fn.js";


### PR DESCRIPTION
Fix module resolution for CJS when TypeScript is set with `node16` or `nodenext`.

Currently, it reports an error when imported, `The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("colorjs.io")' call instead.`, despite it having a package.json `exports`.

It seems that the require and import conditions should have separate type files for TypeScript to be able to resolve CJS modules correctly ([reference](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports)), 

```json
"exports": {
  ".": {
    "import": {
      "default": "./dist/color.js",
      "types": "./types/index.d.ts"
    },
    "require": {
      "default": "./dist/color.cjs",
      "types": "./types/index.d.cts"
    }
  }
}
```
instead of the current one
```json
"exports": {
  ".": {
    "types": "./types/index.d.ts",
    "import": "./dist/color.js",
    "require": "./dist/color.cjs"
  }
}
```

Note also that the `.d.cts` file extension, after testing, specifying `require.types` to the `.d.ts` file doesn't work.
