### PR TITLE
Fix incorrect parsing of Jzazbz percentage values

### DIFF
--- a/src/spaces/jzazbz.js
+++ b/src/spaces/jzazbz.js
@@ -111,6 +111,8 @@ export default new ColorSpace({
 
 	formats: {
 		// https://drafts.csswg.org/css-color-hdr/#Jzazbz
-		"color": {}
+		"color": {
+			coords: ["<number> | <percentage>", "<number> | <percentage>[-1,1]", "<number> | <percentage>[-1,1]"],
+		}
 	}
 });

--- a/tests/parse.html
+++ b/tests/parse.html
@@ -283,6 +283,10 @@
 			<td>color(xyz-d50 0 100% 50%)</td>
 			<td>{"spaceId":"xyz-d50","coords":[0,1,0.5],"alpha":1}</td>
 		</tr>
+		<tr>
+			<td>color(jzazbz 0 25% -50%)</td>
+			<td>{"spaceId":"jzazbz","coords":[0,0.125,-0.25],"alpha":1}</td>
+		</tr>
 		<tr title="With transparency">
 			<td>color(display-p3 0 1 0 / .5)</td>
 			<td>{"spaceId":"p3","coords":[0,1,0],"alpha":0.5}</td>


### PR DESCRIPTION
The `az` and `bz` coordinates for the Jzazbz color space have negative reference range values so percentage values are being mapped incorrectly.

Before this PR
![before](https://github.com/color-js/color.js/assets/65072/5db9c526-30a7-439f-8011-5baf2b9468a6)

After this PR
![after](https://github.com/color-js/color.js/assets/65072/a1196a3c-65ab-4ebd-a53e-f87d9e77dfc8)

The parsing tests haven't been converted to the new format so I added a test case to the old parsing tests.

