### PR TITLE
Fix Luv lightness coordinate name

### DIFF
--- a/src/spaces/luv.js
+++ b/src/spaces/luv.js
@@ -16,7 +16,7 @@ export default new ColorSpace({
 	coords: {
 		l: {
 			refRange: [0, 100],
-			name: "L"
+			name: "Lightness"
 		},
 		// Reference ranges from https://facelessuser.github.io/coloraide/colors/luv/
 		u: {


### PR DESCRIPTION
Changed the Luv `l` coordinate name from `L` to `Lightness` to be consistent with #345.