### PR TITLE
Make color space optional in `getAll()` + `colorSpace.equals()` improvements

### DIFF
--- a/src/getAll.js
+++ b/src/getAll.js
@@ -1,12 +1,17 @@
 import ColorSpace from "./space.js";
 
 /**
- * Get the coordinates of a color in another color space
- *
- * @param {string | ColorSpace} space
- * @returns {number[]}
+ * Get the coordinates of a color in any color space
+ * @param {Color} color
+ * @param {string | ColorSpace} [space = color.space] The color space to convert to. Defaults to the color's current space
+ * @returns {number[]} The color coordinates in the given color space
  */
 export default function getAll (color, space) {
+	if (!space || color.space.equals(space)) {
+		// No conversion needed
+		return color.coords.slice();
+	}
+
 	space = ColorSpace.get(space);
 	return space.from(color);
 }

--- a/src/space.js
+++ b/src/space.js
@@ -158,13 +158,18 @@ export default class ColorSpace {
 		return null;
 	}
 
-	// We cannot rely on simple === because then ColorSpace objects cannot be proxied
+	/**
+	 * Check if this color space is the same as another color space reference.
+	 * Allows proxying color space objects and comparing color spaces with ids.
+	 * @param {string | ColorSpace} space ColorSpace object or id to compare to
+	 * @returns {boolean}
+	 */
 	equals (space) {
 		if (!space) {
 			return false;
 		}
 
-		return this === space || this.id === space.id;
+		return this === space || this.id === space || this.id === space.id;
 	}
 
 	to (space, coords) {

--- a/types/src/getAll.d.ts
+++ b/types/src/getAll.d.ts
@@ -3,5 +3,5 @@ import ColorSpace from "./space.js";
 
 export default function getAll (
 	color: Color | ColorObject,
-	space: string | ColorSpace
+	space?: string | ColorSpace
 ): [number, number, number];

--- a/types/test/getAll.ts
+++ b/types/test/getAll.ts
@@ -4,8 +4,7 @@ import sRGB from "colorjs.io/src/spaces/srgb";
 
 // @ts-expect-error
 getAll();
-// @ts-expect-error
-getAll(new Color("red"));
 
+getAll(new Color("red")); // $ExpectType [number, number, number]
 getAll(new Color("red"), "srgb"); // $ExpectType [number, number, number]
 getAll(new Color("red"), sRGB); // $ExpectType [number, number, number]


### PR DESCRIPTION
This PR does two things:
1. Supports string ids in `colorSpace.equals()` (and adds JSDoc for the method)
2. Makes the color space optional in `getAll()`.
Not only does this make `getAll()` more consistent with the rest of the API, it also sets the stage for option 3 here: https://github.com/color-js/color.js/issues/388#issuecomment-1936678737 . As a side effect, it also implements a performance improvement when the color passed *happens* to be in the same color space as the one specified as it now goes through the same code path.