### PR TITLE
Remove obsolete test:hsluv script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 	},
 	"scripts": {
 		"test": "npx htest ./test",
-		"test:hsluv": "npx htest ./test/hsluv",
 		"dtslint": "dtslint --expectOnly types",
 		"eslint": "eslint . --ext .js --ext .ts --ext .cjs",
 		"lint": "run-s build:space-accessors \"eslint -- --fix\" dtslint",


### PR DESCRIPTION
The `test:hsluv` script became obsolete when the hsluv tests were moved to the top level `test` folder.