### PR TITLE
[types] Add missing overload for `set`

### DIFF
--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -2,7 +2,7 @@ import { WHITES } from "./adapt.js";
 import defaults from "./defaults.js";
 import hooks from "./hooks.js";
 import * as util from "./util.js";
-import ColorSpace from "./space.js";
+import ColorSpace, { Ref } from "./space.js";
 import SpaceAccessors from "./space-coord-accessors.js";
 
 import {
@@ -130,7 +130,6 @@ declare class Color extends SpaceAccessors implements PlainColorObject {
 	// Functions defined using Color.defineFunctions
 	get: ToColorPrototype<typeof get>;
 	getAll: ToColorPrototype<typeof getAll>;
-	set: ToColorPrototype<typeof set>;
 	setAll: ToColorPrototype<typeof setAll>;
 	to: ToColorPrototype<typeof to>;
 	equals: ToColorPrototype<typeof equals>;
@@ -138,6 +137,11 @@ declare class Color extends SpaceAccessors implements PlainColorObject {
 	toGamut: ToColorPrototype<typeof toGamut>;
 	distance: ToColorPrototype<typeof distance>;
 	toString: ToColorPrototype<typeof serialize>;
+
+	// Must be manually defined due to overloads
+	// These should always match the signature of the original function
+	set (prop: Ref, value: number | ((coord: number) => number)): Color;
+	set (props: Record<string, number | ((coord: number) => number)>): Color;
 }
 
 export default Color;

--- a/types/src/set.d.ts
+++ b/types/src/set.d.ts
@@ -6,3 +6,7 @@ export default function set (
 	prop: Ref,
 	value: number | ((coord: number) => number)
 ): Color;
+export default function set (
+	color: ColorTypes,
+	props: Record<string, number | ((coord: number) => number)>
+): Color;

--- a/types/test/set.ts
+++ b/types/test/set.ts
@@ -10,3 +10,9 @@ set("red");
 set("red", "foo", 123); // $ExpectType Color
 set(new Color("red"), ["srgb", "bar"], (_: number) => 123); // $ExpectType Color
 set(new Color("red"), [sRGB, "bar"], (_: number) => 123); // $ExpectType Color
+
+// $ExpectType Color
+set("red", {
+	foo: 123,
+	bar: (_: number) => 123,
+});


### PR DESCRIPTION
The `set` function can also take an object of coordinates to modify, as described in the README: <https://github.com/color-js/color.js#manipulating-colors>

This PR changes the types to reflect this.

The reason that the definition on the `Color` class had to be changed is because of how TypeScript handles overloaded functions in other types (i.e. `ToColorPrototype`). Without this, only the last signature of the `set` function would be present on `Color`.