### PR TITLE
Add core maintainers to website footer.

### DIFF
--- a/_includes/plain.njk
+++ b/_includes/plain.njk
@@ -26,8 +26,14 @@
 </aside>
 
 <footer>
-	From <a href="http://lea.verou.me">Lea Verou</a> (co-editor of CSS Color 4 and 5)
-	and <a href="https://svgees.us">Chris Lilley</a> (co-editor of CSS Color 3, 4, and 5; W3C representative to ICC)
+	Created by <a href="http://lea.verou.me">Lea Verou</a> (co-editor of CSS Color 4 and 5)
+	and <a href="https://svgees.us">Chris Lilley</a> (co-editor of CSS Color 3, 4, and 5; W3C representative to ICC).
+
+	Co-maintained by <a href="https://github.com/facelessuser">Isaac Muse</a>,
+	<a href="https://github.com/jgerigmeyer">Jonny Gerig Meyer</a>,
+	<a href="https://github.com/MysteryBlokHed">Adam Thompson-Sharpe</a>,
+	and <a href="https://github.com/lloydk">Lloyd Kupchanko</a>,
+	with lots of help from a <a href="https://github.com/color-js/color.js/graphs/contributors">community of contributors</a>.
 
 	<nav>
 		{% include "../templates/_nav.njk" %}

--- a/_includes/plain.njk
+++ b/_includes/plain.njk
@@ -31,8 +31,8 @@
 
 	Co-maintained by <a href="https://github.com/facelessuser">Isaac Muse</a>,
 	<a href="https://github.com/jgerigmeyer">Jonny Gerig Meyer</a>,
+	and 
 	<a href="https://github.com/MysteryBlokHed">Adam Thompson-Sharpe</a>,
-	and <a href="https://github.com/lloydk">Lloyd Kupchanko</a>,
 	with lots of help from a <a href="https://github.com/color-js/color.js/graphs/contributors">community of contributors</a>.
 
 	<nav>


### PR DESCRIPTION
Closes #414.

I ordered maintainers by date of first commit to the repo.

cc @lloydk 