### PR TITLE
[website] Fix "Defined in" API links

### DIFF
--- a/api/index.njk
+++ b/api/index.njk
@@ -34,7 +34,7 @@ includes: '<link rel="stylesheet" href="https://mavo.io/docs/style.css">'
 			<p class="[if(!parent, 'hide-on-read')] inherits">
 				Inherits from <a href="#[parent]" property="parent" mv-attribute="none"></a>
 			</p>
-			<p class="defined">Defined in <a href="https://github.com/mavoweb/mavo/blob/master/src/[filename]" property="filename" mv-attribute="none" target="_blank">mavo.js</a></p>
+			<p class="defined">Defined in <a href="https://github.com/color-js/color.js/blob/main/src/[filename]" property="filename" mv-attribute="none" target="_blank">mavo.js</a></p>
 		</summary>
 
 		<p property="description" class="markdown">`Mavo` is the main class. Every Mavo app is an instance of `Mavo` and `mavo.js` is the entry point of Mavo itself.</p>


### PR DESCRIPTION
Currently, the API links on the webpage go to non-existent files on the [mavoweb/mavo](https://github.com/mavoweb/mavo) repository instead of this one. For example, this link goes to <https://github.com/mavoweb/mavo/blob/master/src/color.js>: 

![A screenshot of the API page on colorjs.io. There is a hyperlink on the right, labelled "Defined in color.js"](https://github.com/color-js/color.js/assets/13910387/647b38a9-d41d-48b1-b0cd-89ed8f8a52e9)

This PR fixes the API's `index.njk` file to have the correct link at the base.

