### PR TITLE
Add format to hsv color space

### DIFF
--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -54,5 +54,11 @@ export default new ColorSpace({
 			(l === 0 || l === 1) ? 0 : ((v - l) / Math.min(l, 1 - l)) * 100,
 			l * 100
 		];
+	},
+
+	formats: {
+		color: {
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"]
+		}
 	}
 });

--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -58,6 +58,7 @@ export default new ColorSpace({
 
 	formats: {
 		color: {
+			id: "--hsv",
 			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"]
 		}
 	}

--- a/test/parse.js
+++ b/test/parse.js
@@ -321,7 +321,7 @@ const tests = {
 					expect: '{"spaceId":"hct","coords":[90,72.5,25],"alpha":1}'
 				},
 				{
-					args: "color(hsv 25deg 50% 75)",
+					args: "color(--hsv 25deg 50% 75)",
 					expect: '{"spaceId":"hsv","coords":[25,50,75],"alpha":1}'
 				},
 				{

--- a/test/parse.js
+++ b/test/parse.js
@@ -321,6 +321,10 @@ const tests = {
 					expect: '{"spaceId":"hct","coords":[90,72.5,25],"alpha":1}'
 				},
 				{
+					args: "color(hsv 25deg 50% 75)",
+					expect: '{"spaceId":"hsv","coords":[25,50,75],"alpha":1}'
+				},
+				{
 					name: "With transparency",
 					args: "color(display-p3 0 1 0 / .5)",
 					expect: '{"spaceId":"p3","coords":[0,1,0],"alpha":0.5}'


### PR DESCRIPTION
The hsv color space couldn't be parsed because it didn't have a format entry.

I wasn't sure if the `id` should be `hsv` or `--hsv`. Ideally it should be `--hsv` but I went with `hsv` because even though you couldn't parse hsv colors they were being serialized as `color(hsv ...)` so the serialization is still backwards compatible.