### PR TITLE
Allow hsluv to be gamut mapped using the CSS algorithm

### DIFF
--- a/src/spaces/hsluv.js
+++ b/src/spaces/hsluv.js
@@ -97,11 +97,11 @@ export default new ColorSpace({
 			name: "Hue"
 		},
 		s: {
-			refRange: [0, 100],
+			range: [0, 100],
 			name: "Saturation"
 		},
 		l: {
-			refRange: [0, 100],
+			range: [0, 100],
 			name: "Lightness"
 		}
 	},


### PR DESCRIPTION
The `hsluv` color space wasn't being gamut mapped by the CSS algorithm because it was considered to be an unbounded space and the CSS algorithm exits early if a space is unbounded.

Changing the `s` and `l` coordinates to use `range` instead of `refRange` makes `hsluv` a bounded space and allows it to be gamut mapped properly.

Note that testing if a `hsluv` color was in gamut worked properly because the `gamutSpace` of `hsluv` is `srgb` which is a bounded space.


Convert app with `s` and `l` using `refRange`:

![image](https://github.com/color-js/color.js/assets/65072/ddac2878-c7b9-4948-905e-c0e58c2e4296)


`s` and `l` changed to use `range`:

![image](https://github.com/color-js/color.js/assets/65072/8fdbe83f-6add-4b8e-832b-56b12c7b3c54)



