### PR TITLE
Add missing formats to color spaces

### DIFF
--- a/src/spaces/a98rgb-linear.js
+++ b/src/spaces/a98rgb-linear.js
@@ -23,5 +23,10 @@ export default new RGBColorSpace({
 	name: "Linear Adobe® 98 RGB compatible",
 	white: "D65",
 	toXYZ_M,
-	fromXYZ_M
+	fromXYZ_M,
+	formats: {
+		color: {
+			id: "--a98rgb-linear"
+		}
+	}
 });

--- a/src/spaces/p3-linear.js
+++ b/src/spaces/p3-linear.js
@@ -17,5 +17,10 @@ export default new RGBColorSpace({
 	name: "Linear P3",
 	white: "D65",
 	toXYZ_M,
-	fromXYZ_M
+	fromXYZ_M,
+	formats: {
+		color: {
+			id: "--p3-linear"
+		}
+	}
 });

--- a/src/spaces/prophoto-linear.js
+++ b/src/spaces/prophoto-linear.js
@@ -23,5 +23,10 @@ export default new RGBColorSpace({
 	white: "D50",
 	base: XYZ_D50,
 	toXYZ_M,
-	fromXYZ_M
+	fromXYZ_M,
+	formats: {
+		color: {
+			id: "--prophoto-linear"
+		}
+	}
 });

--- a/src/spaces/xyz-abs-d65.js
+++ b/src/spaces/xyz-abs-d65.js
@@ -35,5 +35,11 @@ export default new ColorSpace({
 	toBase (AbsXYZ) {
 		// Convert to media-white relative XYZ
 		return AbsXYZ.map(v => Math.max(v / Yw, 0));
+	},
+
+	formats: {
+		color: {
+			id: "--xyz-abs-d65"
+		}
 	}
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -325,6 +325,38 @@ const tests = {
 					expect: '{"spaceId":"hsv","coords":[25,50,75],"alpha":1}'
 				},
 				{
+					args: "color(--a98rgb-linear 0 1 .5)",
+					expect: '{"spaceId":"a98rgb-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--a98rgb-linear 0 100% 50%)",
+					expect: '{"spaceId":"a98rgb-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--p3-linear 0 1 .5)",
+					expect: '{"spaceId":"p3-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--p3-linear 0% 100% 50%)",
+					expect: '{"spaceId":"p3-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--prophoto-linear 0 1 .5)",
+					expect: '{"spaceId":"prophoto-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--prophoto-linear 0 100% 50%)",
+					expect: '{"spaceId":"prophoto-linear","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--xyz-abs-d65 0 1 .5)",
+					expect: '{"spaceId":"xyz-abs-d65","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
+					args: "color(--xyz-abs-d65 0 100% 50%)",
+					expect: '{"spaceId":"xyz-abs-d65","coords":[0,1,0.5],"alpha":1}'
+				},
+				{
 					name: "With transparency",
 					args: "color(display-p3 0 1 0 / .5)",
 					expect: '{"spaceId":"p3","coords":[0,1,0],"alpha":0.5}'


### PR DESCRIPTION
Some color spaces couldn't be parsed because they didn't have any formats.

Added formats for:

- a98rgb-linear
- p3-linear
- prophoto-linear
- xyz-abs-d65

I used a dashed-ident for all of the spaces above similar to #430.