### PR TITLE
Add Scale LH2 method

### DIFF
--- a/apps/gamut-mapping/index.html
+++ b/apps/gamut-mapping/index.html
@@ -59,7 +59,7 @@
 				</dd>
 				<dd>
 					<css-color swatch="large" :color="mapped[method].color"></css-color>
-					<dl class="deltas" v-if="!color.inGamut('p3')">
+					<dl class="deltas">
 						<div v-for="(delta, c) of mapped[method].deltas" :class="'delta-' + c.toLowerCase()">
 							<dt>Δ{{ c }}</dt>
 							<dd :class="{

--- a/apps/gamut-mapping/methods.js
+++ b/apps/gamut-mapping/methods.js
@@ -1,4 +1,5 @@
 import Color from "../../dist/color.js";
+import { WHITES } from "../../src/adapt.js";
 
 const methods = {
 	"clip": {
@@ -20,6 +21,38 @@ const methods = {
 				"oklch.h": lch[2]
 			});
 			return methods.scale.compute(mappedColor);
+		}
+	},
+	"scale-lh2": {
+		label: "Scale LH 2",
+		description: "Identical to Scale LH 2, and handles L=0/1, and noop if already in gamut.",
+		compute: (color) => {
+			if (color.inGamut("p3")) {
+				return color.to("p3");
+			}
+			let [lightness] = color.to("oklch").coords;
+			if (lightness >= 1) {
+				return new Color({ space: "xyz-d65", coords: WHITES["D65"] }).to("p3");
+			}
+			else if (lightness <= 0) {
+				return new Color({ space: "xyz-d65", coords: [0, 0, 0] }).to("p3");
+			}
+			let mappedColor = methods.scale.compute(color);
+			let lch = color.to("oklch").coords;
+			mappedColor.set({
+				"oklch.l": lch[0],
+				"oklch.h": lch[2]
+			});
+			// Do not early return if in-gamut already at this point.
+			// The second scale step gets the color closer to the original.
+			mappedColor = methods.scale.compute(mappedColor);
+			if (mappedColor.inGamut("p3")) {
+				return mappedColor;
+			}
+			// Are we mathematically guaranteed to be in gamut at this point?
+			// If not, would a clip suffice?
+			return mappedColor;
+
 		}
 	},
 	"scale": {


### PR DESCRIPTION
This adds an additional method to the Gamut Mapping app that applies the Scale LH method, with a few additions:

- If the color is already in gamut, it returns the input color immediately.
- If L=0, it returns black, and if L=1, it returns white.

It also changes the Gamut Mapping app to always show the delta, even when the original color is in gamut, to help demonstrate when a method might be mapping unnecessarily.