### PR TITLE
[ci] Update lint rules for PR's

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint & Test Types
 on:
     push:
     pull_request:
-        types: [reopened]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/types/src/toGamut.d.ts
+++ b/types/src/toGamut.d.ts
@@ -26,7 +26,13 @@ export interface Options {
 	 * `min` indicates the lower limit for black clamping and `max` indicates the upper
 	 * limit for white clamping
 	 */
-	blackWhiteClamp?: { channel: Ref; min: number; max: number } | undefined;
+	blackWhiteClamp?:
+		| {
+			channel: Ref;
+			min: number;
+			max: number;
+		  }
+		| undefined;
 }
 
 declare namespace toGamut {

--- a/types/src/toGamut.d.ts
+++ b/types/src/toGamut.d.ts
@@ -26,13 +26,7 @@ export interface Options {
 	 * `min` indicates the lower limit for black clamping and `max` indicates the upper
 	 * limit for white clamping
 	 */
-	blackWhiteClamp?:
-		| {
-			channel: Ref;
-			min: number;
-			max: number;
-		  }
-		| undefined;
+	blackWhiteClamp?: { channel: Ref; min: number; max: number } | undefined;
 }
 
 declare namespace toGamut {


### PR DESCRIPTION
A PR I just merged (#436) passed all the CI on the pull request page, but failed once it was merged into main. This is because the lint CI didn't actually run on the PR.

This change makes the CI rerun when a PR is opened, reopened, and when commits are pushed.