### PR TITLE
[types] Fix formatting in `toGamut.d.ts`

### DIFF
--- a/types/src/toGamut.d.ts
+++ b/types/src/toGamut.d.ts
@@ -26,13 +26,7 @@ export interface Options {
 	 * `min` indicates the lower limit for black clamping and `max` indicates the upper
 	 * limit for white clamping
 	 */
-	blackWhiteClamp?:
-		| {
-			channel: Ref;
-			min: number;
-			max: number;
-		  }
-		| undefined;
+	blackWhiteClamp?: { channel: Ref; min: number; max: number } | undefined;
 }
 
 declare namespace toGamut {


### PR DESCRIPTION
There was a formatting error here (from #436) which didn't trigger any eslint errors locally for me, but caused problems once merged into main. This change fixes that error.