### PR TITLE
Add new GMA Scale LH Achromatic

### DIFF
--- a/apps/gamut-mapping/methods.js
+++ b/apps/gamut-mapping/methods.js
@@ -57,6 +57,7 @@ const methods = {
 		},
 
 		lrgbToSrgb: (lrgb) => {
+			// From Prismatic https://studylib.net/doc/14656976/the-prismatic-color-space-for-rgb-computations
 			let rgb = lrgb.slice(1);
 			let l = lrgb[0];
 			let mx = Math.max(...rgb);
@@ -72,6 +73,7 @@ const methods = {
 		},
 
 		srgbToLrgb: (rgb) => {
+			// To Prismatic https://studylib.net/doc/14656976/the-prismatic-color-space-for-rgb-computations
 			let lrgb = [Math.max(...rgb)];
 			let s = rgb.reduce((a, b) => a + b, 0);
 			if (s != 0) {
@@ -90,7 +92,6 @@ const methods = {
 		},
 
 		ilerp: (p0, p1, t) => {
-
 			let d = (p1 - p0);
 			return d !== 0 ? ((t - p0) / d) : 0;
 		},
@@ -99,10 +100,10 @@ const methods = {
 			let delta = 0;
 			let method = methods["scale-lh-achromatic"];
 			let lrgb1 = method.srgbToLrgb(color.coords);
-			let l = lrgb1[0];
 			let lrgb2 = method.srgbToLrgb(achroma.coords);
+			let l = lrgb1[0];
 
-			// Approach the gamut boundary
+			// Find the minimum required delta to get the color into gamut
 			lrgb1.forEach((c, i) => {
 				let d;
 				if (c > 1) {
@@ -116,16 +117,13 @@ const methods = {
 				}
 			});
 
+			// Scale non lightness components
 			if (delta) {
 				lrgb1 = lrgb1.map((c, i) => {
 					return method.lerp(c, lrgb2[i], delta);
 				});
 				let rgb = method.lrgbToSrgb([l, ...lrgb1.slice(1)]);
-				color.set({
-					r: rgb[0],
-					g: rgb[1],
-					b: rgb[2],
-				});
+				color.set({ r: rgb[0], g: rgb[1], b: rgb[2] });
 			}
 		},
 	},

--- a/apps/gamut-mapping/methods.js
+++ b/apps/gamut-mapping/methods.js
@@ -53,7 +53,7 @@ const methods = {
 				});
 			}
 
-			return gamutColor.toGamut({method: 'clip'}).to("p3");
+			return gamutColor.toGamut({method: "clip"}).to("p3");
 		},
 
 		lrgbToSrgb: (lrgb) => {
@@ -99,7 +99,7 @@ const methods = {
 			let delta = 0;
 			let method = methods["scale-lh-achromatic"];
 			let lrgb1 = method.srgbToLrgb(color.coords);
-			let l = lrgb1[0]
+			let l = lrgb1[0];
 			let lrgb2 = method.srgbToLrgb(achroma.coords);
 
 			// Approach the gamut boundary
@@ -127,7 +127,7 @@ const methods = {
 					b: rgb[2],
 				});
 			}
-		}
+		},
 	},
 	"scale": {
 		label: "Scale",


### PR DESCRIPTION
Performs a similar approach as Scale LH, but instead scales color towards the achromatic version of itself. This is performed in a linear light RGB space. When scaling the color towards the achromatic color, it is done in an LRGB form that separates the lightness from the other components. This helps preserve lightness during the process and performs even better, especially in low light blue, which was more problematic in my first attempt.

The procedure is competitive with Scale LH using two iterations, performs even better with 4. 3 iterations was chosen as a middle ground.

Replaces #447 