### PR TITLE
Allow any color type when calling individual deltaE functions

### DIFF
--- a/src/deltaE.js
+++ b/src/deltaE.js
@@ -1,4 +1,3 @@
-import getColor from "./getColor.js";
 import defaults from "./defaults.js";
 import {isString} from "./util.js";
 import deltaEMethods from "./deltaE/index.js";
@@ -9,9 +8,6 @@ export default function deltaE (c1, c2, o = {}) {
 	}
 
 	let {method = defaults.deltaE, ...rest} = o;
-
-	c1 = getColor(c1);
-	c2 = getColor(c2);
 
 	for (let m in deltaEMethods) {
 		if ("deltae" + method.toLowerCase() === m.toLowerCase()) {

--- a/src/deltaE/deltaE2000.js
+++ b/src/deltaE/deltaE2000.js
@@ -1,5 +1,6 @@
 import lab from "../spaces/lab.js";
 import lch from "../spaces/lch.js";
+import getColor from "../getColor.js";
 
 // deltaE2000 is a statistically significant improvement
 // and is recommended by the CIE and Idealliance
@@ -24,6 +25,9 @@ function pow7 (x) {
 }
 
 export default function (color, sample, {kL = 1, kC = 1, kH = 1} = {}) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	// Given this color as the reference
 	// and the function parameter as the sample,
 	// calculate deltaE 2000.

--- a/src/deltaE/deltaE2000.js
+++ b/src/deltaE/deltaE2000.js
@@ -25,8 +25,7 @@ function pow7 (x) {
 }
 
 export default function (color, sample, {kL = 1, kC = 1, kH = 1} = {}) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	// Given this color as the reference
 	// and the function parameter as the sample,

--- a/src/deltaE/deltaE76.js
+++ b/src/deltaE/deltaE76.js
@@ -1,5 +1,6 @@
 import distance from "../distance.js";
+import getColor from "../getColor.js";
 
 export default function deltaE76 (color, sample) {
-	return distance(color, sample, "lab");
+	return distance(getColor(color), getColor(sample), "lab");
 }

--- a/src/deltaE/deltaE76.js
+++ b/src/deltaE/deltaE76.js
@@ -2,5 +2,6 @@ import distance from "../distance.js";
 import getColor from "../getColor.js";
 
 export default function deltaE76 (color, sample) {
-	return distance(getColor(color), getColor(sample), "lab");
+	// Assume getColor() is called in the distance function
+	return distance(color, sample, "lab");
 }

--- a/src/deltaE/deltaECMC.js
+++ b/src/deltaE/deltaECMC.js
@@ -14,8 +14,7 @@ const π = Math.PI;
 const d2r = π / 180;
 
 export default function (color, sample, {l = 2, c = 1} = {}) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	// Given this color as the reference
 	// and a sample,

--- a/src/deltaE/deltaECMC.js
+++ b/src/deltaE/deltaECMC.js
@@ -1,5 +1,6 @@
 import lab from "../spaces/lab.js";
 import lch from "../spaces/lch.js";
+import getColor from "../getColor.js";
 
 // More accurate color-difference formulae
 // than the simple 1976 Euclidean distance in Lab
@@ -13,6 +14,9 @@ const π = Math.PI;
 const d2r = π / 180;
 
 export default function (color, sample, {l = 2, c = 1} = {}) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	// Given this color as the reference
 	// and a sample,
 	// calculate deltaE CMC.

--- a/src/deltaE/deltaEHCT.js
+++ b/src/deltaE/deltaEHCT.js
@@ -1,5 +1,6 @@
 import hct from "../spaces/hct.js";
 import {viewingConditions} from "../spaces/hct.js";
+import getColor from "../getColor.js";
 
 const rad2deg = 180 / Math.PI;
 const deg2rad = Math.PI / 180;
@@ -39,6 +40,9 @@ function convertUcsAb (coords) {
 * @return {number[]}
 */
 export default function (color, sample) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	let [ t1, a1, b1 ] = convertUcsAb(hct.from(color));
 	let [ t2, a2, b2 ] = convertUcsAb(hct.from(sample));
 

--- a/src/deltaE/deltaEHCT.js
+++ b/src/deltaE/deltaEHCT.js
@@ -40,8 +40,7 @@ function convertUcsAb (coords) {
 * @return {number[]}
 */
 export default function (color, sample) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	let [ t1, a1, b1 ] = convertUcsAb(hct.from(color));
 	let [ t2, a2, b2 ] = convertUcsAb(hct.from(sample));

--- a/src/deltaE/deltaEITP.js
+++ b/src/deltaE/deltaEITP.js
@@ -6,8 +6,7 @@ import getColor from "../getColor.js";
 // formulae from ITU Rec. ITU-R BT.2124-0
 
 export default function (color, sample) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	// Given this color as the reference
 	// and a sample,

--- a/src/deltaE/deltaEITP.js
+++ b/src/deltaE/deltaEITP.js
@@ -1,10 +1,14 @@
 import ictcp from "../spaces/ictcp.js";
+import getColor from "../getColor.js";
 
 // Delta E in ICtCp space,
 // which the ITU calls Delta E ITP, which is shorter
 // formulae from ITU Rec. ITU-R BT.2124-0
 
 export default function (color, sample) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	// Given this color as the reference
 	// and a sample,
 	// calculate deltaE in ICtCp

--- a/src/deltaE/deltaEJz.js
+++ b/src/deltaE/deltaEJz.js
@@ -9,8 +9,7 @@ import getColor from "../getColor.js";
 // gives good results.
 
 export default function (color, sample) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	// Given this color as the reference
 	// and a sample,

--- a/src/deltaE/deltaEJz.js
+++ b/src/deltaE/deltaEJz.js
@@ -1,4 +1,5 @@
 import jzczhz from "../spaces/jzczhz.js";
+import getColor from "../getColor.js";
 
 // More accurate color-difference formulae
 // than the simple 1976 Euclidean distance in Lab
@@ -8,6 +9,9 @@ import jzczhz from "../spaces/jzczhz.js";
 // gives good results.
 
 export default function (color, sample) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	// Given this color as the reference
 	// and a sample,
 	// calculate deltaE in JzCzHz.

--- a/src/deltaE/deltaEOK.js
+++ b/src/deltaE/deltaEOK.js
@@ -2,8 +2,12 @@
 // than the simple 1976 Euclidean distance in CIE Lab
 
 import oklab from "../spaces/oklab.js";
+import getColor from "../getColor.js";
 
 export default function (color, sample) {
+	color = getColor(color);
+	sample = getColor(sample);
+
 	// Given this color as the reference
 	// and a sample,
 	// calculate deltaEOK, term by term as root sum of squares

--- a/src/deltaE/deltaEOK.js
+++ b/src/deltaE/deltaEOK.js
@@ -5,8 +5,7 @@ import oklab from "../spaces/oklab.js";
 import getColor from "../getColor.js";
 
 export default function (color, sample) {
-	color = getColor(color);
-	sample = getColor(sample);
+	[color, sample] = getColor([color, sample]);
 
 	// Given this color as the reference
 	// and a sample,

--- a/types/src/deltaE/deltaE2000.d.ts
+++ b/types/src/deltaE/deltaE2000.d.ts
@@ -1,8 +1,8 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject,
+	color: ColorTypes,
+	sample: ColorTypes,
 	options?: {
 		kL?: number | undefined;
 		kC?: number | undefined;

--- a/types/src/deltaE/deltaE76.d.ts
+++ b/types/src/deltaE/deltaE76.d.ts
@@ -1,5 +1,5 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject
+	color: ColorTypes,
+	sample: ColorTypes
 ): number;

--- a/types/src/deltaE/deltaECMC.d.ts
+++ b/types/src/deltaE/deltaECMC.d.ts
@@ -1,7 +1,7 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject,
+	color: ColorTypes,
+	sample: ColorTypes,
 	options?: {
 		l?: number | undefined;
 		c?: number | undefined;

--- a/types/src/deltaE/deltaEHCT.d.ts
+++ b/types/src/deltaE/deltaEHCT.d.ts
@@ -1,5 +1,5 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject
+	color: ColorTypes,
+	sample: ColorTypes
 ): number;

--- a/types/src/deltaE/deltaEITP.d.ts
+++ b/types/src/deltaE/deltaEITP.d.ts
@@ -1,5 +1,5 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject
+	color: ColorTypes,
+	sample: ColorTypes
 ): number;

--- a/types/src/deltaE/deltaEJz.d.ts
+++ b/types/src/deltaE/deltaEJz.d.ts
@@ -1,5 +1,5 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject
+	color: ColorTypes,
+	sample: ColorTypes
 ): number;

--- a/types/src/deltaE/deltaEOK.d.ts
+++ b/types/src/deltaE/deltaEOK.d.ts
@@ -1,5 +1,5 @@
-import Color, { ColorObject } from "../color.js";
+import { ColorTypes } from "../color.js";
 export default function (
-	color: Color | ColorObject,
-	sample: Color | ColorObject
+	color: ColorTypes,
+	sample: ColorTypes
 ): number;

--- a/types/test/deltaE.ts
+++ b/types/test/deltaE.ts
@@ -1,8 +1,18 @@
 import Color from "colorjs.io/src/color";
 import deltaE from "colorjs.io/src/deltaE";
+import deltaE76 from "colorjs.io/src/deltaE/deltaE76";
+import deltaE2000 from "colorjs.io/src/deltaE/deltaE2000";
+import deltaECMC from "colorjs.io/src/deltaE/deltaECMC";
+import deltaEHCT from "colorjs.io/src/deltaE/deltaEHCT";
+import deltaEITP from "colorjs.io/src/deltaE/deltaEITP";
+import deltaEJz from "colorjs.io/src/deltaE/deltaEJz";
+import deltaEOK from "colorjs.io/src/deltaE/deltaEOK";
+import type { ColorObject } from "colorjs.io/src/color";
 
 const c1 = new Color("red");
 const c2 = new Color("blue");
+
+const blue: ColorObject = {spaceId: "srgb", coords: [0, 0, 1]};
 
 // @ts-expect-error
 deltaE();
@@ -13,3 +23,24 @@ deltaE(c1, c2);
 
 deltaE(c1, c2, "2000"); // $ExpectType number
 deltaE(c1, c2, { method: "2000" }); // $ExpectType number
+
+deltaE76(c1, c2); // $ExpectType number
+deltaE76("red", blue); // $ExpectType number
+
+deltaE2000(c1, c2); // $ExpectType number
+deltaE2000("red", blue); // $ExpectType number
+
+deltaECMC(c1, c2); // $ExpectType number
+deltaECMC("red", blue); // $ExpectType number
+
+deltaEHCT(c1, c2); // $ExpectType number
+deltaEHCT("red", blue); // $ExpectType number
+
+deltaEITP(c1, c2); // $ExpectType number
+deltaEITP("red", blue); // $ExpectType number
+
+deltaEJz(c1, c2); // $ExpectType number
+deltaEJz("red", blue); // $ExpectType number
+
+deltaEOK(c1, c2); // $ExpectType number
+deltaEOK("red", blue); // $ExpectType number


### PR DESCRIPTION
The types for the deltaE functions didn't allow all ColorTypes as parameters. For example, the types didn't allow "red" to be passed as a parameter.

Also, calling a deletaE method with a color such as "red" would cause an exception to be thrown.
```javascript
let x = deltaE2000("red", "white") // Exception thrown
```