### PR TITLE
Allow getColor to work with an array of color types

### DIFF
--- a/src/getColor.js
+++ b/src/getColor.js
@@ -4,8 +4,8 @@ import parse from "./parse.js";
 
 /**
  * Resolves a color reference (object or string) to a plain color object
- * @param {Color | {space, coords, alpha} | string} color
- * @returns {{space, coords, alpha}}
+ * @param {Color | {space, coords, alpha} | string | Array<Color | {space, coords, alpha} | string> } color
+ * @returns {{space, coords, alpha} | Array<{space, coords, alpha}}>
  */
 export default function getColor (color) {
 	if (Array.isArray(color)) {

--- a/src/getColor.js
+++ b/src/getColor.js
@@ -8,6 +8,10 @@ import parse from "./parse.js";
  * @returns {{space, coords, alpha}}
  */
 export default function getColor (color) {
+	if (Array.isArray(color)) {
+		return color.map(getColor);
+	}
+
 	if (!color) {
 		throw new TypeError("Empty color reference");
 	}

--- a/types/src/getColor.d.ts
+++ b/types/src/getColor.d.ts
@@ -1,3 +1,4 @@
 import { PlainColorObject, ColorTypes } from "./color.js";
 
 export default function getColor (color: ColorTypes): PlainColorObject;
+export default function getColor (color: ColorTypes[]): PlainColorObject[];

--- a/types/test/getColor.ts
+++ b/types/test/getColor.ts
@@ -4,5 +4,8 @@ import getColor from "colorjs.io/src/getColor";
 // @ts-expect-error
 getColor();
 
-getColor("red");
-getColor(new Color("red"));
+getColor("red"); // $ExpectType PlainColorObject
+getColor(new Color("red")); // $ExpectType PlainColorObject
+
+getColor(["red", "blue"]); // $ExpectType PlainColorObject[]
+


### PR DESCRIPTION
Added the ability to pass an array of color types to getColor.

This allows you to do:
```javascript
let [c1, c2] = getColor(["red", "blue"])
```
instead of the more repetitive
```javascript
let c1 = getColor("red")
let c2 = getColor("blue")
```

As discussed in #451
