### PR TITLE
[toGamut] Avoid round-trip to/from oklch for colors that are in gamut.

### DIFF
--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -7,7 +7,6 @@ import inGamut from "./inGamut.js";
 import to from "./to.js";
 import get from "./get.js";
 import oklab from "./spaces/oklab.js";
-import xyzd65 from "./spaces/xyz-d65.js";
 import set from "./set.js";
 import clone from "./clone.js";
 import getColor from "./getColor.js";
@@ -83,15 +82,15 @@ export default function toGamut (
 	// space: space whose gamut we are mapping to
 	// mapSpace: space with the coord we're reducing
 
+	if (inGamut(color, space, { epsilon: 0 })) {
+		return getColor(color);
+	}
+
 	let spaceColor;
 	if (method === "css") {
-		spaceColor = to(toGamutCSS(color, { space }), color.space);
+		spaceColor = toGamutCSS(color, { space });
 	}
 	else {
-		if (inGamut(color, space, { epsilon: 0 })) {
-			return getColor(color);
-		}
-
 		if (method !== "clip" && !inGamut(color, space)) {
 
 			if (Object.prototype.hasOwnProperty.call(GMAPPRESET, method)) {

--- a/test/gamut.js
+++ b/test/gamut.js
@@ -106,6 +106,20 @@ export default {
 			],
 		},
 		{
+			name: "Does not alter in-gamut colors",
+			data: { toSpace: "hsl" },
+			tests: [
+				{
+					args: ["hsl(0 50% 50%)"],
+					expect: "hsl(0 50% 50%)",
+				},
+				{
+					args: ["hsl(360 50% 50%)"],
+					expect: "hsl(360 50% 50%)",
+				},
+			],
+		},
+		{
 			name: "P3 primaries to sRGB, LCH chroma Reduction",
 			data: { toSpace: "srgb", method: "lch.c" },
 			tests: [


### PR DESCRIPTION
Before:

```js
const color = new Color("hsl(360 50% 50%)");
color.toGamut({ method: "css" }).coords; // [6.661338147750941e-15, 50.000000000000014, 50.000000000000014]
```

After:

```js
const color = new Color("hsl(360 50% 50%)");
color.toGamut({ method: "css" }).coords; // [360, 50, 50]
```