### PR TITLE
Audit function parameter and return types (2/2)

### DIFF
--- a/src/inGamut.js
+++ b/src/inGamut.js
@@ -7,8 +7,13 @@ const ε = .000075;
  * Check if a color is in gamut of either its own or another color space
  * @return {Boolean} Is the color in gamut?
  */
-export default function inGamut (color, space = color.space, {epsilon = ε} = {}) {
+export default function inGamut (color, space, {epsilon = ε} = {}) {
 	color = getColor(color);
+
+	if (!space) {
+		space = color.space;
+	}
+
 	space = ColorSpace.get(space);
 	let coords = color.coords;
 

--- a/src/luminance.js
+++ b/src/luminance.js
@@ -6,10 +6,12 @@ import set from "./set.js";
 import xyz_d65 from "./spaces/xyz-d65.js";
 
 export function getLuminance (color) {
+	// Assume getColor() is called on color in get()
 	return get(color, [xyz_d65, "y"]);
 }
 
 export function setLuminance (color, value) {
+	// Assume getColor() is called on color in set()
 	set(color, [xyz_d65, "y"], value);
 }
 

--- a/src/setAll.js
+++ b/src/setAll.js
@@ -1,6 +1,9 @@
 import ColorSpace from "./space.js";
+import getColor from "./getColor.js";
 
 export default function setAll (color, space, coords) {
+	color = getColor(color);
+
 	space = ColorSpace.get(space);
 	color.coords = space.to(color.space, coords);
 	return color;

--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -65,14 +65,19 @@ export default function toGamut (
 	color,
 	{
 		method = defaults.gamut_mapping,
-		space = color.space,
+		space = undefined,
 		deltaEMethod = "",
 		jnd = 2,
 		blackWhiteClamp = {},
 	} = {},
 ) {
+	color = getColor(color);
+
 	if (util.isString(arguments[1])) {
 		space = arguments[1];
+	}
+	else if (!space) {
+		space = color.space;
 	}
 
 	space = ColorSpace.get(space);
@@ -83,7 +88,7 @@ export default function toGamut (
 	// mapSpace: space with the coord we're reducing
 
 	if (inGamut(color, space, { epsilon: 0 })) {
-		return getColor(color);
+		return color;
 	}
 
 	let spaceColor;
@@ -219,9 +224,16 @@ const COLORS = {
  * @param {ColorSpace|string} options.space
  * @returns {Color}
  */
-export function toGamutCSS (origin, { space = origin.space }) {
+export function toGamutCSS (origin, {space} = {}) {
 	const JND = 0.02;
 	const ε = 0.0001;
+
+	origin = getColor(origin);
+
+	if (!space) {
+		space = origin.space;
+	}
+
 	space = ColorSpace.get(space);
 	const oklchSpace = ColorSpace.get("oklch");
 

--- a/types/src/luminance.d.ts
+++ b/types/src/luminance.d.ts
@@ -1,9 +1,9 @@
-import Color, { ColorObject } from "./color.js";
+import Color, { ColorTypes } from "./color.js";
 
-export function getLuminance (color: Color | ColorObject): number;
+export function getLuminance (color: ColorTypes): number;
 
 export function setLuminance (
-	color: Color | ColorObject,
+	color: ColorTypes,
 	value: number | ((coord: number) => number),
 ): void;
 

--- a/types/src/set.d.ts
+++ b/types/src/set.d.ts
@@ -1,12 +1,12 @@
-import Color, { ColorTypes } from "./color.js";
+import { ColorTypes, PlainColorObject } from "./color.js";
 import { Ref } from "./space.js";
 
 export default function set (
 	color: ColorTypes,
 	prop: Ref,
 	value: number | ((coord: number) => number)
-): Color;
+): PlainColorObject;
 export default function set (
 	color: ColorTypes,
 	props: Record<string, number | ((coord: number) => number)>
-): Color;
+): PlainColorObject;

--- a/types/src/setAll.d.ts
+++ b/types/src/setAll.d.ts
@@ -1,8 +1,14 @@
-import Color, { ColorObject } from "./color.js";
+import Color, { ColorTypes, PlainColorObject } from "./color.js";
 import ColorSpace from "./space.js";
 
-export default function setAll<T extends Color | ColorObject> (
-	color: T,
+declare namespace setAll {
+	let returns: "color";
+}
+
+declare function setAll (
+	color: ColorTypes,
 	space: string | ColorSpace,
 	coords: [number, number, number]
-): T;
+): PlainColorObject;
+
+export default setAll;

--- a/types/src/space.d.ts
+++ b/types/src/space.d.ts
@@ -1,5 +1,5 @@
 import { White } from "./adapt.js";
-import Color, { ColorConstructor, ColorObject, Coords } from "./color.js";
+import Color, { ColorConstructor, ColorObject, Coords, PlainColorObject } from "./color.js";
 
 export interface Format {
 	/** @default "function" */
@@ -127,7 +127,7 @@ export default class ColorSpace {
 	white: White;
 	gamutSpace: ColorSpace;
 
-	from (color: Color | ColorObject): Coords;
+	from (color: {space: ColorSpace, coords: Coords, alpha?: number | undefined}): Coords;
 	from (space: string | ColorSpace, coords: Coords): Coords;
 
 	getFormat (format?: string | Format): Format | null;
@@ -136,7 +136,7 @@ export default class ColorSpace {
 
 	inGamut (coords: Coords, options?: { epsilon?: number }): boolean;
 
-	to (color: Color | ColorObject): Coords;
+	to (color: {space: ColorSpace, coords: Coords, alpha?: number | undefined}): Coords;
 	to (space: string | ColorSpace, coords: Coords): Coords;
 
 	toString (): string;

--- a/types/test/luminance.ts
+++ b/types/test/luminance.ts
@@ -3,10 +3,11 @@ import { getLuminance, setLuminance, register } from "colorjs.io/src/luminance";
 
 // @ts-expect-error
 getLuminance();
-// @ts-expect-error
-getLuminance("red");
 
+getLuminance("red"); // $ExpectType number
 getLuminance(new Color("red")); // $ExpectType number
+new Color("red").luminance; // $ExpectType number
+
 
 // @ts-expect-error
 setLuminance();
@@ -15,8 +16,11 @@ setLuminance("red");
 
 // @ts-expect-error
 setLuminance(new Color("red"));
+
 setLuminance(new Color("red"), 1);
 setLuminance(new Color("red"), () => 1);
+setLuminance("red", 1);
+new Color("red").luminance = 1;
 
 // @ts-expect-error
 register();

--- a/types/test/set.ts
+++ b/types/test/set.ts
@@ -7,12 +7,14 @@ set();
 // @ts-expect-error
 set("red");
 
-set("red", "foo", 123); // $ExpectType Color
-set(new Color("red"), ["srgb", "bar"], (_: number) => 123); // $ExpectType Color
-set(new Color("red"), [sRGB, "bar"], (_: number) => 123); // $ExpectType Color
+set("red", "foo", 123); // $ExpectType PlainColorObject
+set(new Color("red"), ["srgb", "bar"], (_: number) => 123); // $ExpectType PlainColorObject
+set(new Color("red"), [sRGB, "bar"], (_: number) => 123); // $ExpectType PlainColorObject
 
-// $ExpectType Color
+// $ExpectType PlainColorObject
 set("red", {
 	foo: 123,
 	bar: (_: number) => 123,
 });
+
+new Color("red").set("foo", 123); // $ExpectType Color

--- a/types/test/setAll.ts
+++ b/types/test/setAll.ts
@@ -11,9 +11,9 @@ setAll(new Color("red"), "srgb");
 // @ts-expect-error
 setAll(new Color("red"), sRGB);
 
-setAll(new Color("red"), "srgb", [1, 2, 3]); // $ExpectType Color
-setAll(new Color("red"), sRGB, [1, 2, 3]); // $ExpectType Color
-// $ExpectType { coords: [number, number, number]; space: RGBColorSpace; alpha: number; }
+setAll(new Color("red"), "srgb", [1, 2, 3]); // $ExpectType PlainColorObject
+setAll(new Color("red"), sRGB, [1, 2, 3]); // $ExpectType PlainColorObject
+// $ExpectType PlainColorObject
 setAll(
 	{
 		coords: [1, 2, 3],
@@ -23,3 +23,6 @@ setAll(
 	"srgb_linear",
 	[4, 5, 6],
 );
+
+new Color("red").setAll("srgb", [1, 2, 3]); // $ExpectType Color
+new Color("red").setAll(sRGB, [1, 2, 3]); // $ExpectType Color

--- a/types/test/spaces.ts
+++ b/types/test/spaces.ts
@@ -1,3 +1,4 @@
+import Color from "colorjs.io/src";
 import ColorSpace from "colorjs.io/src/space";
 
 // @ts-expect-error
@@ -47,3 +48,16 @@ ColorSpace.registry["abc"]; // $ExpectType ColorSpace
 
 ColorSpace.resolveCoord("p3.0", "p3");
 ColorSpace.resolveCoord(["p3", "r"], "p3");
+
+space.to(new Color("red")); // $ExpectType Coords
+space.to({space: space, coords: [1, 2, 3], alpha: 1}); // $ExpectType Coords
+space.to({space: space, coords: [1, 2, 3]}); // $ExpectType Coords
+space.to(space, [1, 2, 3]); // $ExpectType Coords
+space.to("srgb", [1, 2, 3]); // $ExpectType Coords
+
+space.from(new Color("red")); // $ExpectType Coords
+space.from({space: space, coords: [1, 2, 3], alpha: 1}); // $ExpectType Coords
+space.from({space: space, coords: [1, 2, 3]}); // $ExpectType Coords
+space.from(space, [1, 2, 3]); // $ExpectType Coords
+space.from("srgb", [1, 2, 3]); // $ExpectType Coords
+

--- a/types/test/toGamut.ts
+++ b/types/test/toGamut.ts
@@ -11,3 +11,9 @@ toGamut(new Color("red")); // $ExpectType PlainColorObject
 toGamut(new Color("red"), { method: "clip", space: "srgb" }); // $ExpectType PlainColorObject
 toGamut(new Color("red"), { method: "clip", space: sRGB }); // $ExpectType PlainColorObject
 toGamut(new Color("red"), "srgb"); // $ExpectType PlainColorObject
+
+
+new Color("red").toGamut(); // $ExpectType Color
+new Color("red").toGamut({ method: "clip", space: "srgb" }); // $ExpectType Color
+new Color("red").toGamut({ method: "clip", space: sRGB }); // $ExpectType Color
+new Color("red").toGamut("srgb"); // $ExpectType Color


### PR DESCRIPTION
Ensure that functions in the following modules have the correct types and ensure that all color types can be passed as parameters:

- inGamut
- luminance
- set
- setAll
- space
- toGamut

### space.js
I wasn't sure about the types for the `to` and `from` methods on `Colorspace`. If we allow any color type and call `getColor` in those methods then we introduce a cyclic dependency between the `getColor` module and the `space` module. If we're ok having the cyclic dependency and want to allow any color type I can make the appropriate changes.

