### PR TITLE
[Gamut Mapping App] Always display delta

### DIFF
--- a/apps/gamut-mapping/map-color.js
+++ b/apps/gamut-mapping/map-color.js
@@ -180,7 +180,7 @@ export default {
 					</dt>
 					<dd>
 						<css-color swatch="large" :color="mapped[method].color"></css-color>
-						<dl class="deltas" v-if="!color.inGamut('p3')">
+						<dl class="deltas">
 							<div v-for="(delta, c) of mapped[method].deltas" :class="'delta-' + c.toLowerCase()">
 								<dt>Δ{{ c }}</dt>
 								<dd :class="{


### PR DESCRIPTION
See conversation at https://github.com/color-js/color.js/pull/438#discussion_r1489822585. 

The result of a gamut mapping algorithm may change in-gamut colors, so it is useful to see the deltas in those cases as well.