### PR TITLE
Add spaceKey property to Color.prototype

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -87,6 +87,13 @@ export default class Color {
 		return this.space.id;
 	}
 
+	/**
+	 * Get the Color.prototype.property name for the color space
+	 */
+	get spaceKey () {
+		return this.space.id.replace("-", "_");
+	}
+
 	clone () {
 		return new Color(this.space, this.coords, this.alpha);
 	}


### PR DESCRIPTION
Converts a color space id to a string key that can be used to access a Color instance's color space properties/values.  Essentially, it converts kebab-case to snake_case.  Example usage code:
```
const color1 = new Color("color(xyz-d50 3 1 23)");
const color2 = new Color("lab(23.3 -573 1140)");
color1.coords = color2[color1.spaceKey];          // spaceId = "xyz-d50", spaceKey = "xyz_d50"
// or conversely:
color1[color2.spaceKey] = color2.coords;
```
I use it to read actual `html_element.style` or `getComputedStyle()` values and convert them to my `Color` instance's color space.  The workaround for not having it is simple, but IMO this is a conversion that the library itself should handle.  If not, then never mind...

I have created the property in `Color` and not in `ColorSpace` because it's used by the `Color` instance, not the space.  But if you prefer, it could be added as `ColorSpace.protype.key` instead of or in addition to `Color.prototype.spaceKey`.

The name `spaceKey` is certainly open to change.

Super simple code, and I've tested it locally, but I can't figure out a good way of creating a public test.  Github pages won't build the repo.  Here are the pair of HTML/JavaScript files I used to test it, if that helps (can't attach .html or .js files here and the path to color.js requires editing for your local environment):
https://sidewayss.com/test/testColor1.html
https://sidewayss.com/test/testColor1.js

I think I got it right that because this is a change to the color.js module I should not put any "[text]" in the commit message or PR title.  Let me know if I got that wrong.