### PR TITLE
Allow hwb to accept numbers

### DIFF
--- a/src/spaces/hwb.js
+++ b/src/spaces/hwb.js
@@ -52,7 +52,7 @@ export default new ColorSpace({
 
 	formats: {
 		"hwb": {
-			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"],
 		},
 	},
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -511,6 +511,10 @@ const tests = {
 					args: "hwb(none 20% 30%)",
 					expect: '{"spaceId":"hwb","coords":[null,20,30],"alpha":1}',
 				},
+				{
+					args: "hwb(180 20 30)",
+					expect: '{"spaceId":"hwb","coords":[180,20,30],"alpha":1}',
+				},
 			],
 		},
 	],


### PR DESCRIPTION
Fixes #368

The issue with parsing `none` appears to have been fixed in a prior commit.

