### PR TITLE
Export types at top level of /fn entrypoint.

### DIFF
--- a/types/src/index-fn.d.ts
+++ b/types/src/index-fn.d.ts
@@ -27,3 +27,37 @@ export * from "./deltaE/index.js";
 export { default as deltaEMethods } from "./deltaE/index.js";
 export * from "./variations.js";
 export * from "./spaces/index-fn.js";
+
+export type {
+	ColorConstructor,
+	ColorObject,
+	ColorTypes,
+	Coords,
+	PlainColorObject,
+} from "./color.js";
+
+export type { White } from "./adapt.js";
+
+export type { CAT } from "./CATs.js";
+
+export type { Display } from "./display.js";
+
+export type {
+	Range,
+	RangeOptions,
+	MixOptions,
+	StepsOptions,
+} from "./interpolation.js";
+
+export type { Options as ParseOptions } from "./parse.js";
+
+export type { RGBOptions } from "./rgbspace.js";
+
+export type { Options as SerializeOptions } from "./serialize.js";
+
+export type {
+	Format as SpaceFormat,
+	CoordMeta,
+	Ref,
+	Options as SpaceOptions,
+} from "./space.js";

--- a/types/test/type-fn-accessibility.ts
+++ b/types/test/type-fn-accessibility.ts
@@ -1,0 +1,32 @@
+// Testing whether types can be accessed from the /fn import
+
+import {
+	// Re-exported from src/color.d.ts
+	ColorConstructor,
+	ColorObject,
+	ColorTypes,
+	Coords,
+	PlainColorObject,
+	// Re-exported from src/adapt.d.ts
+	White,
+	// Re-exported from src/CATs.d.ts
+	CAT,
+	// Re-exported from src/display.d.ts
+	Display,
+	// Re-exported from src/interpolation.d.ts
+	Range,
+	RangeOptions,
+	MixOptions,
+	StepsOptions,
+	// Re-exported from src/parse.d.ts
+	ParseOptions,
+	// Re-exported from src/rgbspace.d.ts
+	RGBOptions,
+	// Re-exported from src/serialize.d.ts
+	SerializeOptions,
+	// Re-exported from src/space.d.ts
+	SpaceFormat,
+	CoordMeta,
+	Ref,
+	SpaceOptions,
+} from "colorjs.io/fn";

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -10,6 +10,10 @@
 		"noEmit": true,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",
-		"paths": { "colorjs.io": ["."], "colorjs.io/*": ["./*"] }
+		"paths": {
+			"colorjs.io": ["."],
+			"colorjs.io/fn": ["./src/index-fn.js"],
+			"colorjs.io/*": ["./*"]
+		}
 	}
 }


### PR DESCRIPTION
This is a missing corollary of https://github.com/color-js/color.js/pull/327