### PR TITLE
Document how to serve in development, and add `--serve` to `watch:html`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,12 @@ We use 11ty for processing CSS and HTML for the website, and Rollup.js for bundl
 2. `cd` to the project directory and run `npm install` to install local modules
 3. Done! Now run `npm run build` to build.
 
-Run `npm run watch:html` before you start working on the website to build automatically as you edit files.
+Run `npm run watch` before you start working on the website to build
+automatically as you edit files. This also serves the website at http://localhost:8080/.
 
 Or, for individual tasks:
 
-- `npm run watch:html` to build HTML
+- `npm run watch:html` to build HTML and run a development server.
 - `npm run watch:css` to process PostCSS files (`*.src.css` in our repo)
 - `npm run watch:js` to create Color.js bundles in `dist/`
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"build:space-accessors": "node ./scripts/generate-space-accessor-types.js",
 		"build": "run-s build:html build:css build:js build:js:legacy build:space-accessors",
 		"watch:css": "npx postcss \"**/*.postcss\" --base . --dir . --ext .css --config postcss.config.cjs --watch",
-		"watch:html": "npx @11ty/eleventy --config=.eleventy.cjs --watch",
+		"watch:html": "npx @11ty/eleventy --config=.eleventy.cjs --watch --serve",
 		"watch:js": "rollup -c --watch",
 		"watch": "run-p watch:*",
 		"prepack": "npm run build",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"build:space-accessors": "node ./scripts/generate-space-accessor-types.js",
 		"build": "run-s build:html build:css build:js build:js:legacy build:space-accessors",
 		"watch:css": "npx postcss \"**/*.postcss\" --base . --dir . --ext .css --config postcss.config.cjs --watch",
-		"watch:html": "npx @11ty/eleventy --config=.eleventy.cjs --watch --serve",
+		"watch:html": "npx @11ty/eleventy --config=.eleventy.cjs --serve",
 		"watch:js": "rollup -c --watch",
 		"watch": "run-p watch:*",
 		"prepack": "npm run build",


### PR DESCRIPTION
The current npm scripts for development don't include a way to serve the built files. Because 11ty contains a dev server, we can use that. 

This adds the `--serve` flag to `npm run watch:html` (and by extension `npm run watch`) so that developers don't need to separately serve the content.

If this is disruptive to existing workflows, we could add an alternate `npm run dev` that would watch css, js and html, and also serve. Alternatively, we could document how to serve with `npx http-server`, but since the functionality is already available through 11ty, this seems like a higher burden on contributors.