### PR TITLE
[apps/gamut-mapping] Add gradient tool view

### DIFF
--- a/apps/gamut-mapping/gradients.css
+++ b/apps/gamut-mapping/gradients.css
@@ -1,0 +1,36 @@
+:root {
+	--font-mono: Consolas, Inconsolata, Monaco, monospace;
+}
+
+body {
+	font: 100%/1.5 system-ui;
+	max-width: 84em;
+	margin: 1em auto;
+	padding-inline: 1em;
+
+	.gradient {
+		height: 100px;
+    display: flex;
+    > div {
+      flex: auto;
+      background: var(--step-color);
+    }
+	}
+  .color-inputs {
+		display: flex;
+		justify-content: space-between;
+	}
+
+  .oog .gradient{
+    height: 15px;
+  }
+
+	.method .info {
+		display: none;
+	}
+	.gradients:not(.flush) {
+		.method .info {
+			display: block;
+		}
+	}
+}

--- a/apps/gamut-mapping/gradients.css
+++ b/apps/gamut-mapping/gradients.css
@@ -10,20 +10,20 @@ body {
 
 	.gradient {
 		height: 100px;
-    display: flex;
-    > div {
-      flex: auto;
-      background: var(--step-color);
-    }
+		display: flex;
+		> div {
+			flex: auto;
+			background: var(--step-color);
+		}
 	}
-  .color-inputs {
+	.color-inputs {
 		display: flex;
 		justify-content: space-between;
 	}
 
-  .oog .gradient{
-    height: 15px;
-  }
+	.oog .gradient {
+		height: 15px;
+	}
 
 	.method .info {
 		display: none;

--- a/apps/gamut-mapping/gradients.html
+++ b/apps/gamut-mapping/gradients.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Gamut Mapping Experiments - Gradients</title>
+	<link rel="stylesheet" href="gradients.css" />
+	<link rel="shortcut icon" />
+	<script type="module" src="../../elements/css-color/css-color.js"></script>
+	<script type="module" src="gradients.js"></script>
+</head>
+<body>
+	<header>
+		<h1>Gamut Mapping Gradients</h1>
+		<p>Use keyboard arrow keys to increment/decrement, share by copying the URL</p>
+	</header>
+	<div class="controls">
+		<label for="space">Interpolation space:</label>
+		<select v-model="space" name="space">
+			<option v-for="space in interpolationSpaces" :value="space">{{ space }}</option>
+		</select><br/>
+		<label for="maxDeltaE">Max DeltaE between steps:</label>
+		<input v-model="maxDeltaE" type="number" min="1" name="maxDeltaE"/><br/>
+		<div>{{steps.length}} Gradient Steps</div>
+		<label for="flush">Flush:</label> <input type="checkbox" v-model="flush" name="flush">
+	</div>
+	<div class="color-inputs">
+		<css-color swatch="large" @colorchange="event => colorNullable = event.detail.color" :value="from">
+			<input v-model="from" />
+		</css-color>
+		<css-color swatch="large" @colorchange="event => colorNullable = event.detail.color" :value="to">
+			<input v-model="to" />
+		</css-color>
+	</div>
+	<div class="mapped-gradient oog">
+		<div class="info"><strong>Gamut indicator</strong></div>
+		<div class="gradient">
+			<div v-for="[title, step] in oogSteps" :style="{'--step-color': step}" :title="title"></div>
+		</div> 
+	</div>
+	<div :class="{flush, 'gradients': true}">
+		<article class="method" v-for="(i, method) of methods">
+			<mapped-gradient :key="i" :steps="steps" :method="i"/>
+		</article>
+	</div>
+</body>
+</html>

--- a/apps/gamut-mapping/gradients.js
+++ b/apps/gamut-mapping/gradients.js
@@ -1,0 +1,73 @@
+import { createApp } from "https://unpkg.com/vue@3.2.37/dist/vue.esm-browser.js";
+import Color from "../../dist/color.js";
+import methods from "./methods.js";
+import Gradient from "./mapped-gradient.js";
+
+globalThis.Color = Color;
+
+let app = createApp({
+	data () {
+		let params = new URLSearchParams(location.search);
+		let urlFromColor = params.getAll("from").filter(Boolean);
+		let urlToColor = params.getAll("to").filter(Boolean);
+		return {
+			methods: ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker"],
+			Color,
+			from: "oklch(90% .8 250)",
+			to: "oklch(40% .1 20)",
+			space: "oklch",
+			maxDeltaE: 10,
+			flush: false,
+			interpolationSpaces: ["oklch", "oklab", "p3", "rec2020", "lab"],
+		};
+	},
+
+	computed: {
+		colors () {
+			return [this.from, this.to];
+		},
+
+		steps () {
+			const from = new Color(this.colors[0]);
+			const to = new Color(this.colors[1]);
+			let steps = from.steps(to, {
+				maxDeltaE: this.maxDeltaE,
+				space: this.space,
+			});
+			return steps;
+		},
+		oogSteps () {
+			return this.steps.map(step => {
+				switch (true) {
+					case step.inGamut("srgb"):
+						return ["in srgb", "yellowgreen"];
+					case step.inGamut("p3"):
+						return ["in p3", "gold"];
+					case step.inGamut("rec2020"):
+						return ["in rec2020", "orange"];
+					default:
+						return ["out of rec2020", "red"];
+				}
+			});
+		},
+	},
+
+	methods: {
+
+	},
+
+	watch: {
+
+	},
+
+	components: {
+		"mapped-gradient": Gradient,
+	},
+	compilerOptions: {
+		isCustomElement (tag) {
+			return tag === "css-color";
+		},
+	},
+}).mount(document.body);
+
+globalThis.app = app;

--- a/apps/gamut-mapping/mapped-gradient.js
+++ b/apps/gamut-mapping/mapped-gradient.js
@@ -1,0 +1,66 @@
+import methods from "./methods.js";
+
+export default {
+	props: {
+		method: String | Object,
+		steps: Array,
+	},
+
+	data () {
+		return {
+			time: 0,
+			mappedSteps: [],
+		};
+	},
+
+	computed: {
+		name () {
+			return methods[this.method]?.label || "None";
+		},
+	},
+
+	methods: {
+		mapSteps () {
+			const start = performance.now();
+			let steps = this.steps.map(step => {
+				let mappedColor;
+				if (this.method === "none") {
+					return step;
+				}
+				if (methods[this.method].compute) {
+					mappedColor = methods[this.method].compute(step);
+				}
+				else {
+					mappedColor = step.clone().toGamut({ space: "p3", method: this.method });
+				}
+				return mappedColor;
+			});
+			this.time = Color.util.toPrecision(performance.now() - start, 4);
+			this.mappedSteps = steps;
+		},
+	},
+
+	watch: {
+		steps: {
+			handler () {
+				this.mapSteps();
+			},
+			immediate: true,
+		},
+	},
+
+	compilerOptions: {
+		isCustomElement (tag) {
+			return tag === "css-color";
+		},
+	},
+
+	template: `
+	<div :style="style" class="mapped-gradient">
+		<div class="info"><strong>{{ name }}</strong> {{time}}ms</div>
+		<div class="gradient" :title="name">
+			<div v-for="step in mappedSteps" :style="{'--step-color': step}" :title="step"></div>
+		</div>
+	</div>
+		`,
+};


### PR DESCRIPTION
This adds a way to explore and compare the gamut mapping algorithms across a gradient. 

Essentially, it uses the Color.js steps function to create steps between 2 colors in a space you pick, and then applies the gamut mapping method to each step.

It currently shows the speed of calculating each method, as well as a bar that shows when the gradient is out of the srgb, p3 and rec2020 gamuts.

<img width="1034" alt="image" src="https://github.com/color-js/color.js/assets/167908/f6cbaf69-337e-4d5d-b63d-8ec6821a4811">

I'm open to feature ideas. Some I'd like to add are sorting or showing a subset of methods, and show different distance calculations (DeltaE, L, H) per step, especially as those are added in #437.

Remaining blocking tasks

- [ ] Get colors from URL
- [ ] Handle invalid color inputs