### PR TITLE
fix: add optional chaining in the event `CSS` is null

### DIFF
--- a/src/display.js
+++ b/src/display.js
@@ -13,7 +13,7 @@ defaults.display_space = sRGB;
 
 let supportsNone;
 
-if (typeof CSS !== "undefined" && CSS.supports) {
+if (typeof CSS !== "undefined" && CSS?.supports) {
 	// Find widest supported color space for CSS
 	for (let space of [Lab, REC2020, P3]) {
 		let coords = space.getMinCoords();

--- a/src/display.js
+++ b/src/display.js
@@ -42,7 +42,7 @@ if (typeof CSS !== "undefined" && CSS.supports) {
 export default function display (color, {space = defaults.display_space, ...options} = {}) {
 	let ret = serialize(color, options);
 
-	if (typeof CSS === "undefined" || CSS.supports("color", ret) || !defaults.display_space) {
+	if (typeof CSS === "undefined" || CSS?.supports("color", ret) || !defaults.display_space) {
 		ret = new String(ret);
 		ret.color = color;
 	}


### PR DESCRIPTION
Adding this in the event that `CSS` global is null this doesn't throw an error. There was a user that went thru this code path and `CSS` was null and threw an error.