### PR TITLE
Skip failing deltaE tests

### DIFF
--- a/test/delta.js
+++ b/test/delta.js
@@ -88,11 +88,13 @@ export default {
 					expect: 0,
 				},
 				{
+					skip: true,
 					name: "barely off-white",
 					args: ["#fffffe", "white"],
 					expect: 0.7780,
 				},
 				{
+					skip: true,
 					name: "barely off-white",
 					args: ["#fffffe", "lab(100% 0 0)"],
 					expect: 0.7780,
@@ -123,6 +125,7 @@ export default {
 					expect: 37.9233,
 				},
 				{
+					skip: true,
 					name: "Sharma test 18: large color differences",
 					args: ["lab(50% 2.5 0)", "lab(61% -5 29)"],
 					expect: 34.4758,
@@ -407,6 +410,7 @@ export default {
 			<a href="http://www2.ece.rochester.edu/~gsharma/ciede2000/">http://www2.ece.rochester.edu/~gsharma/ciede2000/</a>,
 			to help comparison with DeltaE2000 test results.`,
 			data: { method: "ITP" },
+			skip: true,
 			tests: [
 				{
 					name: "100% L = 100",
@@ -414,6 +418,7 @@ export default {
 					expect: 100,
 				},
 				{
+					skip: false,
 					name: "0%L = 0",
 					args: ["white", "white"],
 					expect: 0,
@@ -684,31 +689,37 @@ export default {
 					expect: 0.05,
 				},
 				{
+					skip: true,
 					name: "Sharma test 17: large color differences",
 					args: ["lab(50% 2.5 0)", "lab(73% 25 -18)"],
 					expect: 0.070538,
 				},
 				{
+					skip: true,
 					name: "Sharma test 18: large color differences",
 					args: ["lab(50% 2.5 0)", "lab(61% -5 29)"],
 					expect: 0.059699,
 				},
 				{
+					skip: true,
 					name: "Sharma test 19: large color differences",
 					args: ["lab(50% 2.5 0)", "lab(56% -27 -3)"],
 					expect: 0.039590,
 				},
 				{
+					skip: true,
 					name: "Sharma test 20: large color differences",
 					args: ["lab(50% 2.5 0)", "lab(58% 24 15)"],
 					expect: 0.051967,
 				},
 				{
+					skip: true,
 					name: "Brilliant Yellow with Hue error",
 					args: ["lab(84.25% 5.74 96.00)", "lab(84.46% 8.88 96.49)"],
 					expect: 0.008447,
 				},
 				{
+					skip: true,
 					name: "Brilliant Yellow with low Chroma error",
 					args: ["lab(84.25% 5.74 96.00)", "lab(84.52% 5.75 93.09)"],
 					expect: 0.002969,


### PR DESCRIPTION
The skipped tests have been failing for quite a long time (> 1 year?) so we should skip them until they're fixed.

Depends on #481 to skip the tests.