### PR TITLE
[Gamut mapping App] Add port of Chromium Gamut mapping app

### DIFF
--- a/apps/gamut-mapping/gradients.js
+++ b/apps/gamut-mapping/gradients.js
@@ -12,7 +12,7 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .8 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker"];
+		const methods = ["none", "chromium", "clip", "scale-lh", "css", "raytrace", "edge-seeker"];
 		const runResults = {};
 		methods.forEach(method => runResults[method] = []);
 		return {

--- a/apps/gamut-mapping/gradients.js
+++ b/apps/gamut-mapping/gradients.js
@@ -12,7 +12,7 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .8 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "chromium", "clip", "scale-lh", "css", "raytrace", "edge-seeker"];
+		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "chromium"];
 		const runResults = {};
 		methods.forEach(method => runResults[method] = []);
 		return {

--- a/apps/gamut-mapping/gradients.js
+++ b/apps/gamut-mapping/gradients.js
@@ -12,7 +12,7 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .8 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "baked-in"];
+		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "chromium"];
 		const runResults = {};
 		methods.forEach(method => runResults[method] = []);
 		return {

--- a/apps/gamut-mapping/gradients.js
+++ b/apps/gamut-mapping/gradients.js
@@ -12,7 +12,7 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .8 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "chromium"];
+		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "baked-in"];
 		const runResults = {};
 		methods.forEach(method => runResults[method] = []);
 		return {

--- a/apps/gamut-mapping/methods.js
+++ b/apps/gamut-mapping/methods.js
@@ -174,8 +174,9 @@ const methods = {
 			// Attenuate the ab coordinate by alpha.
 			return oklab.set({a: alpha * a, b: alpha * b})
 			// Implementation difference: The reference algorithm does not include a
-			// final clip, so some colors may be outside of `rec2020`.
-				.toGamut({method: "clip", space: "rec2020"});
+			// final clip, so some resulting colors may be outside of `rec2020`, and
+			// here we clip to p3 for comparison with other methods.
+				.toGamut({method: "clip", space: "p3"});
 		},
 	},
 	"raytrace": {

--- a/apps/gamut-mapping/methods.js
+++ b/apps/gamut-mapping/methods.js
@@ -50,9 +50,9 @@ const methods = {
 			return new Color("p3-linear", scaledCoords).to("p3");
 		},
 	},
-	"baked-in": {
-		label: "Baked in",
-		description: "A port of the Chromium implementation, mapping to an approximation of the rec2020 gamut.",
+	"chromium": {
+		label: "Chromium",
+		description: "A port of the 'baked-in' Chromium implementation, mapping to an approximation of the rec2020 gamut.",
 		compute: (color) => {
 			// Implementation difference: The reference algorithm does not appear to
 			// return early for in-gamut colors.


### PR DESCRIPTION
This ports the algorithm available behind a flag in Chrome Canary, implemented [here](https://chromium-review.googlesource.com/c/chromium/src/+/5147800/13/ui/gfx/color_conversions.cc). 

The approach appears to be different from the others, reach roughly the same results as the CSS algorithm, and is as fast as clip.

I expect that there could be additional cleanup, this was intended to be as straight of a port as possible from the original code.

- [x] Verify what color space it is mapping to - rec2020
- [x] Don't map in-gamut colors
- [x] Can produce colors out of p3 gamut- should it be clipped? Added clip to rec2020.