### PR TITLE
Speed up hsluv tests

### DIFF
--- a/test/hpluv.js
+++ b/test/hpluv.js
@@ -1,4 +1,4 @@
-import Color from "../src/index.js";
+import { to, sRGB, HPLuv } from "../src/index-fn.js";
 import { check } from "./util.mjs";
 import { readTestData, normalizeCoords } from "./hsluv/util.mjs";
 
@@ -7,19 +7,17 @@ let srgbToHpluv = [];
 let hpluvToSrgb = [];
 
 Object.entries(json).forEach(([rgbHex, value]) => {
-	let coords = normalizeCoords(value["hpluv"]);
-	srgbToHpluv.push({ args: rgbHex, expect: coords });
-
-	let color = `color(--hpluv ${coords[0]} ${coords[1]} ${coords[2]})`;
-	hpluvToSrgb.push({ args: color, expect: value.rgb });
+	let coords = normalizeCoords(value.hpluv);
+	let rgb = value.rgb;
+	srgbToHpluv.push({ args: {space: sRGB, coords: rgb, alpha: 1}, expect: coords });
+	hpluvToSrgb.push({ args: {space: HPLuv, coords: coords, alpha: 1}, expect: rgb });
 });
 
 const tests = {
 	name: "HPLuv Conversion Tests",
 	description: "These tests compare sRGB values against the HSLuv reference implementation snapshot data.",
 	run (color, spaceId = this.data.toSpace) {
-		color = new Color(color);
-		return color.to(spaceId).coords;
+		return to(color, spaceId).coords;
 	},
 	check: check.deep(function (actual, expect) {
 		if (expect === null || Number.isNaN(expect)) {
@@ -37,14 +35,14 @@ const tests = {
 		{
 			name: "sRGB to HPLuv",
 			data: {
-				toSpace: "hpluv",
+				toSpace: HPLuv,
 			},
 			tests: srgbToHpluv,
 		},
 		{
 			name: "HPLuv to sRGB",
 			data: {
-				toSpace: "srgb",
+				toSpace: sRGB,
 			},
 			tests: hpluvToSrgb,
 		},

--- a/test/hsluv.js
+++ b/test/hsluv.js
@@ -1,4 +1,4 @@
-import Color from "../src/index.js";
+import { to, sRGB, HSLuv } from "../src/index-fn.js";
 import { check } from "./util.mjs";
 import { readTestData, normalizeCoords } from "./hsluv/util.mjs";
 
@@ -7,19 +7,17 @@ let srgbToHsluv = [];
 let hsluvToSrgb = [];
 
 Object.entries(json).forEach(([rgbHex, value]) => {
-	let coords = normalizeCoords(value["hsluv"]);
-	srgbToHsluv.push({ args: rgbHex, expect: coords });
-
-	let color = `color(--hsluv ${coords[0]} ${coords[1]} ${coords[2]})`;
-	hsluvToSrgb.push({ args: color, expect: value.rgb });
+	let coords = normalizeCoords(value.hsluv);
+	let rgb = value.rgb;
+	srgbToHsluv.push({ args: {space: sRGB, coords: rgb, alpha: 1}, expect: coords });
+	hsluvToSrgb.push({ args: {space: HSLuv, coords: coords, alpha: 1}, expect: rgb });
 });
 
 const tests = {
 	name: "HSLuv Conversion Tests",
 	description: "These tests compare sRGB values against the HSLuv reference implementation snapshot data.",
-	run (color, spaceId = this.data.toSpace) {
-		color = new Color(color);
-		return color.to(spaceId).coords;
+	run (color, space = this.data.toSpace) {
+		return space.from(color);
 	},
 	check: check.deep(function (actual, expect) {
 		if (expect === null || Number.isNaN(expect)) {
@@ -37,14 +35,14 @@ const tests = {
 		{
 			name: "sRGB to HSLuv",
 			data: {
-				toSpace: "hsluv",
+				toSpace: HSLuv,
 			},
 			tests: srgbToHsluv,
 		},
 		{
 			name: "HSLuv to sRGB",
 			data: {
-				toSpace: "srgb",
+				toSpace: sRGB,
 			},
 			tests: hsluvToSrgb,
 		},


### PR DESCRIPTION
Eliminates parsing of color strings and uses object literals instead of Color objects resulting in a 3-4x speed up.