### PR TITLE
Move HSLuv and HPLuv tests to hsluv directory

### DIFF
--- a/test/hsluv/hpluv.js
+++ b/test/hsluv/hpluv.js
@@ -1,6 +1,6 @@
-import { to, sRGB, HPLuv } from "../src/index-fn.js";
-import { check } from "./util.mjs";
-import { readTestData, normalizeCoords } from "./hsluv/util.mjs";
+import { to, sRGB, HPLuv } from "../../src/index-fn.js";
+import { check } from "../util.mjs";
+import { readTestData, normalizeCoords } from "./util.mjs";
 
 let json = readTestData();
 let srgbToHpluv = [];

--- a/test/hsluv/hsluv.js
+++ b/test/hsluv/hsluv.js
@@ -1,6 +1,6 @@
-import { to, sRGB, HSLuv } from "../src/index-fn.js";
-import { check } from "./util.mjs";
-import { readTestData, normalizeCoords } from "./hsluv/util.mjs";
+import { to, sRGB, HSLuv } from "../../src/index-fn.js";
+import { check } from "../util.mjs";
+import { readTestData, normalizeCoords } from "./util.mjs";
 
 let json = readTestData();
 let srgbToHsluv = [];


### PR DESCRIPTION
There are a large number of tests in the HSLuv and HPLuv test suites and there's no need to run them everytime so they have been moved out of the primary test suite into their own test directory.

The hsluv and hpluv tests can be run using `npx htest test/hsluv`.
 
Closes #487 
