### PR TITLE
[eslint] Ignore `api/` directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 !.*
 assets/js/prism.js
+api/
 /dist/
 docs/
 node_modules/


### PR DESCRIPTION
The lint & test workflow is currently failing since eslint is running against generated files. This adds the `api/` directory to the ignore file to fix this.