### PR TITLE
[docs] Point typedoc at `.d.ts` files instead of `.js`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"skipLibCheck": true
 	},
 	"include": [
-		"src/**/*.js"
+		"types/src/**/*.d.ts"
 	],
 	"exclude": [
 		"node_modules/**"

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,11 +3,11 @@
 	"json": "./api/docs.json",
 	"name": "Color.js API Docs",
 	"entryPoints": [
-		"src/color.js",
-		"src/space.js",
-		"src/index-fn.js",
-		"src/spaces/index.js",
-		"src/deltaE/index.js"
+		"types/src/color.d.ts",
+		"types/src/space.d.ts",
+		"types/src/index-fn.d.ts",
+		"types/src/spaces/index.d.ts",
+		"types/src/deltaE/index.d.ts"
 	],
 	"entryPointStrategy": "expand",
 	"plugin": [

--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @packageDocumentation
+ * Class that represents a single color.
+ * All of Color.js’s tree-shakeable methods are also available as instance methods on this class,
+ * as well as static methods that take the color as the first argument.
+ */
 import { WHITES } from "./adapt.js";
 import defaults from "./defaults.js";
 import hooks from "./hooks.js";
@@ -98,6 +104,7 @@ declare namespace Color {
 	export function set (color: ColorTypes, props: Record<string, number | ((coord: number) => number)>): Color;
 }
 
+/** The main Color class */
 declare class Color extends SpaceAccessors implements PlainColorObject {
 	constructor (color: ColorTypes);
 	constructor (space: string | ColorSpace, coords: Coords, alpha?: number);


### PR DESCRIPTION
Closes #496

TypeDoc was set to use the JavaScript files for source, meaning all JSDoc from the TypeScript files was being ignored. This PR sets it to use the TS files instead, documenting types/interfaces and using the newer JSDoc.