### PR TITLE
[types] Add more module documentation

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -18,10 +18,10 @@
 	"kindSortOrder": [
 		"Project",
 		"Module",
-		"Namespace",
 		"Enum",
 		"EnumMember",
 		"Class",
+		"Namespace",
 		"Interface",
 		"TypeAlias",
 		"Constructor",

--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -1,8 +1,6 @@
 /**
  * @packageDocumentation
- * Class that represents a single color.
- * All of Color.js’s tree-shakeable methods are also available as instance methods on this class,
- * as well as static methods that take the color as the first argument.
+ * This module defines the main {@link Color} class as well as the types it uses.
  */
 import { WHITES } from "./adapt.js";
 import defaults from "./defaults.js";
@@ -104,7 +102,11 @@ declare namespace Color {
 	export function set (color: ColorTypes, props: Record<string, number | ((coord: number) => number)>): Color;
 }
 
-/** The main Color class */
+/**
+ * Class that represents a single color.
+ * All of Color.js’s tree-shakeable methods are also available as instance methods on this class,
+ * as well as static methods that take the color as the first argument.
+ */
 declare class Color extends SpaceAccessors implements PlainColorObject {
 	constructor (color: ColorTypes);
 	constructor (space: string | ColorSpace, coords: Coords, alpha?: number);

--- a/types/src/deltaE/index.d.ts
+++ b/types/src/deltaE/index.d.ts
@@ -1,3 +1,7 @@
+/**
+ * @packageDocumentation
+ * This module defines all the builtin deltaE methods.
+ */
 export { default as deltaE76 } from "./deltaE76.js";
 export { default as deltaECMC } from "./deltaECMC.js";
 export { default as deltaE2000 } from "./deltaE2000.js";
@@ -9,6 +13,10 @@ export { default as deltaEHCT } from "./deltaEHCT.js";
 declare const deltaEMethods: Omit<typeof import("./index.js"), "default">;
 export default deltaEMethods;
 
+/**
+ * A type including all the names of the builtin deltaE methods,
+ * generated from the names of the deltaE functions.
+ */
 export type Methods = keyof typeof deltaEMethods extends `deltaE${infer Method}`
 	? Method
 	: string;

--- a/types/src/index-fn.d.ts
+++ b/types/src/index-fn.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @packageDocumentation
+ * A functional, tree-shakeable version of the Color.js API.
+ * This module allows developers to selectively import
+ * the classes and functions that they wish to use in their project.
+ */
 export { default as ColorSpace } from "./space.js";
 export { default as RGBColorSpace } from "./rgbspace.js";
 export { default as hooks, Hooks } from "./hooks.js";

--- a/types/src/space.d.ts
+++ b/types/src/space.d.ts
@@ -1,3 +1,8 @@
+/**
+ * @packageDocumentation
+ * Defines the class and other types related to creating color spaces.
+ * For the builtin color spaces, see the `spaces` module.
+ */
 import { White } from "./adapt.js";
 import { ColorConstructor, Coords, ColorTypes } from "./color.js";
 
@@ -26,7 +31,7 @@ export interface Format {
 	/**
 	 * Serialize coordinates and an alpha channel into a string.
 	 * Must be defined for a format to support serialization
-	*/
+	 */
 	serialize?: ((coords: Coords, alpha: number, opts?: Record<string, any>) => string) | undefined;
 }
 
@@ -47,7 +52,7 @@ export interface Options {
 	/**
 	 * Function that converts coords in the base color space to coords in this color space.
 	 * Must perform chromatic adaptation if needed
-	*/
+	 */
 	fromBase?: ((coords: Coords) => number[]) | undefined;
 	/**
 	 * Function that converts coords in this color space to coords in the base color space.
@@ -57,7 +62,7 @@ export interface Options {
 	/**
 	 * Object mapping coord ids to coord metadata
 	 * @see {@link CoordMeta}
-	*/
+	 */
 	coords?: Record<string, CoordMeta> | undefined;
 	white?: string | White | undefined;
 	/** The ID used by CSS, such as `display-p3` or `--cam16-jmh` */
@@ -66,7 +71,7 @@ export interface Options {
 	/**
 	 * Details about string formats to parse from / serialize to
 	 * @see {@link Format}
-	*/
+	 */
 	formats?: Record<string, Format> | undefined;
 	gamutSpace?: "self" | string | ColorSpace | null | undefined;
 }

--- a/types/src/spaces/index-fn.d.ts
+++ b/types/src/spaces/index-fn.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @packageDocumentation
+ * Re-exports all the spaces built into Color.js.
+ */
+
+/** A list of all the builtin color spaces. */
 export type Spaces = keyof typeof import("./index-fn.js");
 
 export { default as XYZ_D65 } from "./xyz-d65.js";

--- a/types/src/spaces/index.d.ts
+++ b/types/src/spaces/index.d.ts
@@ -1,3 +1,7 @@
+/**
+ * @packageDocumentation
+ * This module contains {@link spaces a namespace} with all the spaces built into Color.js.
+ */
 import * as spaces from "./index-fn.js";
 
 export { Spaces } from "./index-fn.js";


### PR DESCRIPTION
This PR makes some improvements to type documentation. Namely:

- Adding `@packageDocumentation` tags to all entrypoints (otherwise they are undescribed in the docs)
- Changing the sort priority to put namespaces _after_ classes. I did this because namespaces are sometimes used to add additional properties to classes, but IMO they shouldn't be listed before classes in the docs.

For the namespaces part: an example of where this can be seen as a problem is on the `color` module page (<https://colorjs.io/api/modules/color.html>). In the sidebar, the first `Color` property listed is the namespace instead of the class.