### PR TITLE
Fix types for `setAll()`

### DIFF
--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -19,7 +19,6 @@ import {
 	equals as equalsFn,
 	get,
 	getAll as getAllFn,
-	setAll as setAllFn,
 	display,
 } from "./index-fn.js";
 
@@ -84,7 +83,6 @@ export type ToColorNamespace<T extends (...args: any[]) => any> = T extends (
 declare namespace Color {
 	// Functions defined using Color.defineFunctions
 	export const getAll: ToColorNamespace<typeof getAllFn>;
-	export const setAll: ToColorNamespace<typeof setAllFn>;
 	export const to: ToColorNamespace<typeof toFn>;
 	export const equals: ToColorNamespace<typeof equalsFn>;
 	export const inGamut: ToColorNamespace<typeof inGamutFn>;
@@ -100,6 +98,8 @@ declare namespace Color {
 	// These should always match the signature of the original function
 	export function set (color: ColorTypes, prop: Ref, value: number | ((coord: number) => number)): Color;
 	export function set (color: ColorTypes, props: Record<string, number | ((coord: number) => number)>): Color;
+	export function setAll (color: ColorTypes, coords: Coords, alpha?: number): Color;
+	export function setAll (color: ColorTypes, space: string | ColorSpace, coords: Coords, alpha?: number): Color;
 }
 
 /**
@@ -152,7 +152,6 @@ declare class Color extends SpaceAccessors implements PlainColorObject {
 	// Functions defined using Color.defineFunctions
 	get: ToColorPrototype<typeof get>;
 	getAll: ToColorPrototype<typeof getAllFn>;
-	setAll: ToColorPrototype<typeof setAllFn>;
 	to: ToColorPrototype<typeof toFn>;
 	equals: ToColorPrototype<typeof equalsFn>;
 	inGamut: ToColorPrototype<typeof inGamutFn>;
@@ -164,6 +163,8 @@ declare class Color extends SpaceAccessors implements PlainColorObject {
 	// These should always match the signature of the original function
 	set (prop: Ref, value: number | ((coord: number) => number)): Color;
 	set (props: Record<string, number | ((coord: number) => number)>): Color;
+	setAll (coords: Coords, alpha?: number): Color;
+	setAll (space: string | ColorSpace, coords: Coords, alpha?: number): Color;
 }
 
 export default Color;

--- a/types/src/setAll.d.ts
+++ b/types/src/setAll.d.ts
@@ -7,8 +7,15 @@ declare namespace setAll {
 
 declare function setAll (
 	color: ColorTypes,
+	coords: [number, number, number],
+	alpha?: number | undefined
+): PlainColorObject;
+
+declare function setAll (
+	color: ColorTypes,
 	space: string | ColorSpace,
-	coords: [number, number, number]
+	coords: [number, number, number],
+	alpha?: number | undefined
 ): PlainColorObject;
 
 export default setAll;

--- a/types/test/setAll.ts
+++ b/types/test/setAll.ts
@@ -13,6 +13,11 @@ setAll(new Color("red"), sRGB);
 
 setAll(new Color("red"), "srgb", [1, 2, 3]); // $ExpectType PlainColorObject
 setAll(new Color("red"), sRGB, [1, 2, 3]); // $ExpectType PlainColorObject
+
+setAll("red", "srgb", [1, 2, 3], 0.5); // $ExpectType PlainColorObject
+setAll("red", [1, 2, 3]); // $ExpectType PlainColorObject
+setAll("red", [1, 2, 3], 0.5); // $ExpectType PlainColorObject
+
 // $ExpectType PlainColorObject
 setAll(
 	{
@@ -26,5 +31,8 @@ setAll(
 
 new Color("red").setAll("srgb", [1, 2, 3]); // $ExpectType Color
 new Color("red").setAll(sRGB, [1, 2, 3]); // $ExpectType Color
+new Color("red").setAll("srgb", [1, 2, 3], 0.5); // $ExpectType Color
 Color.setAll("red", "srgb", [1, 2, 3]); // $ExpectType Color
 Color.setAll(new Color("red"), "srgb", [1, 2, 3]); // $ExpectType Color
+Color.setAll("red", "srgb", [1, 2, 3], 0.5); // $ExpectType Color
+Color.setAll("red", [1, 2, 3], 0.5); // $ExpectType Color


### PR DESCRIPTION
Add overloaded functions for `setAll()` to allow for optional `space` and `alpha` parameters which were added in https://github.com/color-js/color.js/commit/493d5f453ae4c0b885cc92bf39f46ed37460c0d3 and https://github.com/color-js/color.js/commit/77c09ad4df49a80bc5f5febd28236350dd382139.