### PR TITLE
[types] Update `Coords` type to allow `null`

### DIFF
--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -24,7 +24,7 @@ import {
 
 export type { SpaceAccessor } from "./space-coord-accessors.js";
 
-export type Coords = [number, number, number];
+export type Coords = [number | null, number | null, number | null];
 
 export interface ColorObject {
 	spaceId?: string | ColorSpace | undefined;

--- a/types/test/color.ts
+++ b/types/test/color.ts
@@ -1,4 +1,4 @@
-import Color from "colorjs.io/src/color";
+import Color, { Coords } from "colorjs.io/src/color";
 
 // @ts-expect-error
 new Color();
@@ -18,5 +18,7 @@ color.clone(); // $ExpectType Color
 
 color.display();
 color.display({ space: "srgb" });
+
+const coords: Coords = [1, 2, null];
 
 // Most other color methods are those defined in other files, so they aren't tested here


### PR DESCRIPTION
Closes #527

Allows `null` to be used in `Coords` types, as should be allowed after #409.