### PR TITLE
[website] Add Discord link to nav links

### DIFF
--- a/_includes/partials/_nav-links.njk
+++ b/_includes/partials/_nav-links.njk
@@ -11,4 +11,5 @@
 <a href="https://elements.colorjs.io/">Elements</a>
 <a href="{{ page | relative }}/test/" class="footer">Tests</a>
 <a href="https://github.com/LeaVerou/color.js">GitHub</a>
+<a href="https://discord.gg/K64FJBznq4" class="footer">Discord</a>
 <a href="https://github.com/LeaVerou/color.js/issues/new" class="footer">File bug</a>

--- a/_includes/partials/_nav-links.njk
+++ b/_includes/partials/_nav-links.njk
@@ -11,5 +11,5 @@
 <a href="https://elements.colorjs.io/">Elements</a>
 <a href="{{ page | relative }}/test/" class="footer">Tests</a>
 <a href="https://github.com/LeaVerou/color.js">GitHub</a>
-<a href="https://discord.gg/K64FJBznq4" class="footer">Discord</a>
+<a href="https://discord.gg/K64FJBznq4">Discord</a>
 <a href="https://github.com/LeaVerou/color.js/issues/new" class="footer">File bug</a>


### PR DESCRIPTION
Related issue: #412

This change uses the Discord invite linked from the referenced issue. Currently, the only change is adding a link to the navbar. I could also add some kind of "need help?" section to the homepage that's harder to miss, if that'd be desired.