### PR TITLE
Demonstrate JND with colours that are different

### DIFF
--- a/docs/color-difference.md
+++ b/docs/color-difference.md
@@ -87,7 +87,7 @@ Can you notice a difference in the two colors below?
 
 ```js
 let color1 = new Color("lch", [40, 50, 60]);
-let color2 = new Color("lch", [40, 50, 60]);
+let color2 = new Color("lch", [43, 50, 60]);
 
 color1.deltaE(color2, "76");
 color1.deltaE(color2, "CMC");


### PR DESCRIPTION
The "Color differences" page in the docs illustrates the Just Noticeable Difference (JND) with a pair of identical colours. This patch changes one of them slightly.

I don't know what the original intention was, although I assume that there being no difference isn't deliberate. So I went with a change that meant that ΔΕ > 2.3 for two of the three algorithms demonstrated. My thinking was that this gives the reader a chance to judge these algorithms (and/or the 2.3 threshold) against their own ability to see a difference.