### PR TITLE
Fix RGBColorSpace type tests

### DIFF
--- a/types/test/RGBColorSpace.ts
+++ b/types/test/RGBColorSpace.ts
@@ -1,4 +1,4 @@
-import RGBColorSpace from "colorjs.io/src/rgbspace";
+import RGBColorSpace from "colorjs.io/src/RGBColorSpace.js";
 
 // @ts-expect-error
 new RGBColorSpace();


### PR DESCRIPTION
Fixed the import of the RGBColorSpace and renamed the test file to match the module name.