### PR TITLE
Fix toGamut() types

### DIFF
--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -50,7 +50,7 @@ const GMAPPRESET = {
  * Force coordinates to be in gamut of a certain color space.
  * Mutates the color it is passed.
  * @param {ColorTypes} color
- * @param {ToGamutOptions} param1
+ * @param {ToGamutOptions | string} param1
  * @returns {PlainColorObject}
  */
 


### PR DESCRIPTION
Allow a ColorSpace id to be specifed for the second param.