### PR TITLE
Fix getAll() types

### DIFF
--- a/src/getAll.js
+++ b/src/getAll.js
@@ -7,7 +7,7 @@ import getColor from "./getColor.js";
 /**
  * Get the coordinates of a color in any color space
  * @param {ColorTypes} color
- * @param {string | ColorSpace} space The color space to convert to. Defaults to the color's current space
+ * @param {string | ColorSpace} [space] The color space to convert to. Defaults to the color's current space
  * @returns {Coords} The color coordinates in the given color space
  */
 export default function getAll (color, space) {


### PR DESCRIPTION
Changes the `space` param to be optional.