### PR TITLE
[docs] Ignore errors in JS files for typedoc

### DIFF
--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "allowJs": true,
+        "checkJs": false
+    }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
 	"out": "./api",
 	"json": "./api/docs.json",
 	"name": "Color.js API Docs",
+	"tsconfig": "./tsconfig.typedoc.json",
 	"entryPoints": [
 		"src/types.d.ts",
 		"src/color.d.ts",


### PR DESCRIPTION
This should prevent type errors from stopping site deployments.