### PR TITLE
Fix serialization of negative percentages

### DIFF
--- a/src/Type.js
+++ b/src/Type.js
@@ -40,7 +40,7 @@ export default class Type {
 			return this.range;
 		}
 		if (this.type === "<percentage>") {
-			return [-1, 1];
+			return this.pctRange();
 		}
 		else if (this.type === "<angle>") {
 			return [0, 360];
@@ -72,7 +72,7 @@ export default class Type {
 		let toRange = this.coordRange;
 
 		if (this.type === "<percentage>") {
-			toRange ??= [-1, 1];
+			toRange ??= this.pctRange();
 		}
 
 		return mapRange(fromRange, toRange, number);
@@ -84,7 +84,8 @@ export default class Type {
 	 * @param {number} [precision]
 	 */
 	serialize (number, precision) {
-		let toRange = this.type === "<percentage>" ? [-100, 100] : this.computedRange;
+		let toRange = this.type === "<percentage>" ? this.pctRange(100) : this.computedRange;
+
 		let unit = this.unit;
 
 		number = mapRange(this.coordRange, toRange, number);
@@ -102,6 +103,15 @@ export default class Type {
 		}
 
 		return ret;
+	}
+
+	/**
+	 * Returns a percentage range for values of this type
+	 * @param {number} scale
+	 */
+	pctRange (scale = 1) {
+		let range = this.coordRange && this.coordRange[0] < 0 ? [-1, 1] : [0, 1];
+		return range.map(v => v * scale);
 	}
 
 	static get (type, ...args) {

--- a/src/Type.js
+++ b/src/Type.js
@@ -109,7 +109,7 @@ export default class Type {
 	 * Returns a percentage range for values of this type
 	 * @param {number} scale
 	 */
-	pctRange (scale = 1) {
+	percentageRange (scale = 1) {
 		let range = this.coordRange && this.coordRange[0] < 0 ? [-1, 1] : [0, 1];
 		return range.map(v => v * scale);
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -112,21 +112,7 @@ export function mapRange (from, to, value) {
 		return value;
 	}
 
-	// Make sure 0 is mapped to 0
-	let [minFrom, maxFrom] = from;
-	let [minTo, maxTo] = to;
-
-	// We assume max* is positive
-	if (value < 0) {
-		maxFrom = Math.min(0, maxFrom);
-		maxTo = Math.min(0, maxTo);
-	}
-	else {
-		minFrom = Math.max(0, minFrom);
-		minTo = Math.max(0, minTo);
-	}
-
-	return interpolate(minTo, maxTo, interpolateInv(minFrom, maxFrom, value));
+	return interpolate(to[0], to[1], interpolateInv(from[0], from[1], value));
 }
 
 /**

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -138,6 +138,46 @@ const tests = {
 				},
 			],
 		},
+		{
+			name: "Values outside of range or refRange",
+			tests: [
+				{
+					name: "sRGB negative %",
+					args: ["srgb", [-0.5, 0, 0], 1, {inGamut: false}],
+					expect: "rgb(-50% 0% 0%)",
+				},
+				{
+					name: "sRGB %",
+					args: ["srgb", [1.5, 0, 0], 1, {inGamut: false}],
+					expect: "rgb(150% 0% 0%)",
+				},
+				{
+					name: "sRGB %, inGamut: true",
+					args: ["srgb", [-0.5, 0, 0], 1],
+					expect: "rgb(0% 0% 0%)",
+				},
+				{
+					name: "rgb()  with <number> coords",
+					args: ["srgb", [2, 2, 2], 1, {inGamut: false, coords: ["<number>[0,255]", "<number>[0,255]", "<number>[0,255]"]}],
+					expect: "rgb(510 510 510)",
+				},
+				{
+					name: "oklch negative values",
+					args: ["oklch", [-0.1, -0.6, -50], 1],
+					expect: "oklch(-10% -0.6 -50)",
+				},
+				{
+					name: "hsl negative values",
+					args: ["hsl", [-50, -10, -30], 1, {inGamut: false}],
+					expect: "hsl(-50 -10% -30%)",
+				},
+				{
+					name: "hsl positive values",
+					args: ["hsl", [400, 123, 456], 1, {inGamut: false}],
+					expect: "hsl(400 123% 456%)",
+				},
+			],
+		},
 	],
 };
 


### PR DESCRIPTION
Closes #552

Changes the hard coded percentage ranges to a variable range based on whether or not the lower bounds of the range is < 0. Spaces that do not have coordinate ranges (e.g. xyz-d65) will have a percentage range of [0, 1] and [0, 100].
