### PR TITLE
[types] Re-export types for `index` and `index-fn`

### DIFF
--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -34,3 +34,41 @@ export {default as deltaEMethods}       from "./deltaE/index.js";
 export *                                from "./variations.js";
 export { mix, steps, range, isRange }   from "./interpolation.js";
 export *                                from "./spaces/index-fn.js";
+
+// Type re-exports
+// Re-exported from src/color.d.ts
+/** @typedef {import("./types.js").ColorConstructor} ColorConstructor */
+/** @typedef {import("./types.js").ColorObject} ColorObject */
+/** @typedef {import("./types.js").ColorTypes} ColorTypes */
+/** @typedef {import("./types.js").Coords} Coords */
+/** @typedef {import("./types.js").DefineFunctionCode} DefineFunctionCode */
+/** @typedef {import("./types.js").DefineFunctionOptions} DefineFunctionOptions */
+/** @typedef {import("./types.js").DefineFunctionHybrid} DefineFunctionHybrid */
+/** @typedef {import("./types.js").PlainColorObject} PlainColorObject */
+/** @typedef {import("./types.js").SpaceAccessor} SpaceAccessor */
+/**
+ * @typedef {import("./types.js").ToColorPrototype<T>} ToColorPrototype
+ * @template {(...args: any[]) => any} T
+ */
+// Re-exported from src/adapt.d.ts
+/** @typedef {import("./types.js").White} White */
+// Re-exported from src/CATs.d.ts
+/** @typedef {import("./types.js").CAT} CAT */
+// Re-exported from src/display.d.ts
+/** @typedef {import("./types.js").Display} Display */
+// Re-exported from src/interpolation.d.ts
+/** @typedef {import("./types.js").Range} Range */
+/** @typedef {import("./types.js").RangeOptions} RangeOptions */
+/** @typedef {import("./types.js").MixOptions} MixOptions */
+/** @typedef {import("./types.js").StepsOptions} StepsOptions */
+// Re-exported from src/parse.d.ts
+/** @typedef {import("./types.js").ParseOptions} ParseOptions */
+// Re-exported from src/rgbspace.d.ts
+/** @typedef {import("./types.js").RGBOptions} RGBOptions */
+// Re-exported from src/serialize.d.ts
+/** @typedef {import("./types.js").SerializeOptions} SerializeOptions */
+// Re-exported from src/space.d.ts
+/** @typedef {import("./types.js").Format} SpaceFormat */
+/** @typedef {import("./types.js").CoordMeta} CoordMeta */
+/** @typedef {import("./types.js").Ref} Ref */
+/** @typedef {import("./types.js").SpaceOptions} SpaceOptions */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,43 @@ import { range, Range, MixOptions, StepsOptions } from "./interpolation.js";
 import { getLuminance } from "./luminance.js";
 import { lighten, darken } from "./variations.js";
 
+// Type re-exports
+export {
+	// Re-exported from src/color.d.ts
+	ColorConstructor,
+	ColorObject,
+	ColorTypes,
+	Coords,
+	DefineFunctionCode,
+	DefineFunctionOptions,
+	DefineFunctionHybrid,
+	PlainColorObject,
+	SpaceAccessor,
+	ToColorPrototype,
+	// Re-exported from src/adapt.d.ts
+	White,
+	// Re-exported from src/CATs.d.ts
+	CAT,
+	// Re-exported from src/display.d.ts
+	Display,
+	// Re-exported from src/interpolation.d.ts
+	Range,
+	RangeOptions,
+	MixOptions,
+	StepsOptions,
+	// Re-exported from src/parse.d.ts
+	ParseOptions,
+	// Re-exported from src/rgbspace.d.ts
+	RGBOptions,
+	// Re-exported from src/serialize.d.ts
+	SerializeOptions,
+	// Re-exported from src/space.d.ts
+	Format as SpaceFormat,
+	CoordMeta,
+	Ref,
+	SpaceOptions,
+} from "./types.js";
+
 // Augment existing Color object
 declare module "./color" {
 	export default class Color {


### PR DESCRIPTION
Closes #551
Fixes a regression caused by #540

Re-exports types that were previously exported in `index.js` and `index-fn.js`.

If anyone knows a better way to re-export the `index-fn` types other than what I've done (a series of `@typedef` statements), I'm open to suggestions.

Also: note that the "re-exported from..." comments are currently actually incorrect—they come from the test files and indicate where the types _used_ to be defined. I can remove or alter these comments if desired.