### PR TITLE
[types] Fix type errors in codebase

### DIFF
--- a/src/CATs.js
+++ b/src/CATs.js
@@ -21,10 +21,7 @@ hooks.add("chromatic-adaptation-end", env => {
 	}
 });
 
-/**
- * @param {CAT} param0
- */
-export function defineCAT ({id, toCone_M, fromCone_M}) {
+export function defineCAT (/** @type {CAT} */ {id, toCone_M, fromCone_M}) {
 	// Use id, toCone_M, fromCone_M like variables
 	CATs[id] = arguments[0];
 }

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -127,8 +127,8 @@ export default class ColorSpace {
 	aliases?: string[] | undefined;
 	base: ColorSpace | null;
 	coords: Record<string, CoordMeta>;
-	fromBase?: ((coords: Coords) => number[]) | undefined;
-	toBase?: ((coords: Coords) => number[]) | undefined;
+	fromBase?: ((coords: Coords) => Coords) | undefined;
+	toBase?: ((coords: Coords) => Coords) | undefined;
 	formats: Record<string, Format>;
 	referred?: string | undefined;
 	white: White;

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -16,6 +16,7 @@ export interface Format {
 	id?: string | undefined;
 	coords?: string[] | undefined;
 	coordGrammar?: (string & { range?: [number, number] })[] | undefined;
+	space?: ColorSpace | undefined;
 	serializeCoords?:
 	| ((coords: Coords, precision: number) => [string, string, string])
 	| undefined;

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -107,7 +107,7 @@ export default class ColorSpace {
 		workingSpace?: string | ColorSpace
 	): CoordMeta & {
 		id: string;
-		index: string | number;
+		index: number;
 		space: ColorSpace;
 	};
 

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -77,6 +77,7 @@ export interface SpaceOptions {
 	 */
 	formats?: Record<string, Format> | undefined;
 	gamutSpace?: "self" | string | ColorSpace | null | undefined;
+	aliases?: string[] | undefined;
 }
 
 export type Ref =
@@ -118,7 +119,8 @@ export default class ColorSpace {
 
 	static registry: Record<string, ColorSpace>;
 
-	get all (): Set<ColorSpace>;
+	static get all (): ColorSpace[];
+
 	/** The ID used by CSS, such as `display-p3` or `--cam16-jmh` */
 	get cssId (): string;
 	get isPolar (): boolean;

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -138,7 +138,7 @@ export default class ColorSpace {
 	from (color: ColorTypes): Coords;
 	from (space: string | ColorSpace, coords: Coords): Coords;
 
-	getFormat (format?: string | Format): Format | null;
+	getFormat (format?: string | Format | FormatClass): FormatClass | null;
 
 	getMinCoords (): Coords;
 

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -14,6 +14,7 @@ export interface Format {
 	/** @default "color" */
 	name?: string | undefined;
 	id?: string | undefined;
+	ids?: string[] | undefined;
 	coords?: string[] | undefined;
 	coordGrammar?: (string & { range?: [number, number] })[] | undefined;
 	space?: ColorSpace | undefined;

--- a/src/Format.js
+++ b/src/Format.js
@@ -21,6 +21,7 @@ export const instance = Symbol("instance");
 
 /**
  * @class Format
+ * @implements {Omit<FormatInterface, "coords" | "serializeCoords">}
  * Class to hold a color serialization format
  */
 export default class Format {

--- a/src/Format.js
+++ b/src/Format.js
@@ -3,6 +3,7 @@ import Type from "./Type.js";
 
 // Type "imports"
 /** @typedef {import("./types.js").ColorSpace} ColorSpace */
+/** @typedef {import("./types.js").Coords} Coords */
 /** @typedef {import("./types.js").Format} FormatInterface */
 
 /**
@@ -13,6 +14,12 @@ import Type from "./Type.js";
 export const instance = Symbol("instance");
 
 /**
+ * Remove the first element of an array type
+ * @template {any[]} T
+ * @typedef {T extends [any, ...infer R] ? R : T[number][]} RemoveFirstElement
+*/
+
+/**
  * @class Format
  * Class to hold a color serialization format
  */
@@ -21,7 +28,7 @@ export default class Format {
 	type;
 	name;
 	spaceCoords;
-	/** @type {[Type, Type, Type]} */
+	/** @type {Type[][]} */
 	coords;
 
 	/**
@@ -45,6 +52,7 @@ export default class Format {
 		this.spaceCoords = Object.values(space.coords);
 
 		if (!this.coords) {
+			// @ts-expect-error Strings are converted to the correct type later
 			this.coords = this.spaceCoords.map(coordMeta => {
 				let ret = ["<number>", "<percentage>"];
 
@@ -56,7 +64,7 @@ export default class Format {
 			});
 		}
 
-		this.coords = this.coords.map((types, i) => {
+		this.coords = this.coords.map(/** @param {string | string[] | Type[]} types */ (types, i) => {
 			let coordMeta = this.spaceCoords[i];
 
 			if (typeof types === "string") {
@@ -67,6 +75,11 @@ export default class Format {
 		});
 	}
 
+	/**
+	 * @param {Coords} coords
+	 * @param {number} precision
+	 * @param {Type[]} types
+	 */
 	serializeCoords (coords, precision, types) {
 		types = coords.map((_, i) => Type.get(types?.[i] ?? this.coords[i][0], this.spaceCoords[i]));
 		return coords.map((c, i) => types[i].serialize(c, precision));
@@ -75,10 +88,8 @@ export default class Format {
 	/**
  	 * Validates the coordinates of a color against a format's coord grammar and
 	 * maps the coordinates to the range or refRange of the coordinates.
-	 * @param {ColorSpace} space - Colorspace the coords are in
-	 * @param {object} format - the format object to validate against
-	 * @param {string} name - the name of the color function. e.g. "oklab" or "color"
-	 * @returns {number[]} - Mapped coords
+	 * @param {Coords} coords
+	 * @param {[string, string, string]} types
 	 */
 	coerceCoords (coords, types) {
 		return Object.entries(this.space.coords).map(([id, coordMeta], i) => {
@@ -98,7 +109,7 @@ export default class Format {
 			if (!type) {
 				// Type does not exist in the grammar, throw
 				let coordName = coordMeta.name || id;
-				throw new TypeError(`${ providedType ?? arg?.raw ?? arg } not allowed for ${coordName} in ${this.name}()`);
+				throw new TypeError(`${ providedType ?? /** @type {any} */ (arg)?.raw ?? arg } not allowed for ${coordName} in ${this.name}()`);
 			}
 
 			arg = type.resolve(arg);
@@ -112,13 +123,21 @@ export default class Format {
 		});
 	}
 
+	/**
+	 * @returns {boolean | Required<FormatInterface>["serialize"]}
+	 */
 	canSerialize () {
-		return this.type === "function" || this.serialize;
+		return this.type === "function" || /** @type {any} */ (this).serialize;
 	}
 
+	/**
+	 * @param {Format | FormatInterface} format
+	 * @param {RemoveFirstElement<ConstructorParameters<typeof Format>>} args
+	 * @returns {Format}
+	 */
 	static get (format, ...args) {
 		if (!format || format instanceof Format) {
-			return format;
+			return /** @type {Format} */ (format);
 		}
 
 		if (format[instance]) {

--- a/src/RGBColorSpace.js
+++ b/src/RGBColorSpace.js
@@ -39,7 +39,7 @@ export default class RGBColorSpace extends ColorSpace {
 
 		if (options.toXYZ_M && options.fromXYZ_M) {
 			options.toBase ??= rgb => {
-				let xyz = multiplyMatrices(options.toXYZ_M, rgb);
+				let xyz = /** @type {[number, number, number]} */ (multiplyMatrices(options.toXYZ_M, rgb));
 
 				if (this.white !== this.base.white) {
 					// Perform chromatic adaptation

--- a/src/Type.js
+++ b/src/Type.js
@@ -5,6 +5,8 @@ export default class Type {
 	type;
 	coordMeta;
 	coordRange;
+	/** @type {[number, number]} */
+	range;
 
 	/**
 	 * @param {any} type
@@ -35,6 +37,7 @@ export default class Type {
 		}
 	}
 
+	/** @returns {[number, number]} */
 	get computedRange () {
 		if (this.range) {
 			return this.range;
@@ -89,9 +92,7 @@ export default class Type {
 		let unit = this.unit;
 
 		number = mapRange(this.coordRange, toRange, number);
-		number = serializeNumber(number, {unit, precision});
-
-		return number;
+		return serializeNumber(number, {unit, precision});
 	}
 
 	toString () {
@@ -108,10 +109,11 @@ export default class Type {
 	/**
 	 * Returns a percentage range for values of this type
 	 * @param {number} scale
+	 * @returns {[number, number]}
 	 */
 	percentageRange (scale = 1) {
 		let range = this.coordRange && this.coordRange[0] < 0 ? [-1, 1] : [0, 1];
-		return range.map(v => v * scale);
+		return /** @type {[number, number]} */ (range.map(v => v * scale));
 	}
 
 	static get (type, ...args) {

--- a/src/adapt.js
+++ b/src/adapt.js
@@ -70,7 +70,7 @@ export default function adapt (W1, W2, XYZ, options = {}) {
 	hooks.run("chromatic-adaptation-end", env);
 
 	if (env.M) {
-		return multiplyMatrices(env.M, env.XYZ);
+		return /** @type {[number, number, number]} */ (multiplyMatrices(env.M, env.XYZ));
 	}
 	else {
 		throw new TypeError("Only Bradford CAT with white points D50 and D65 supported for now.");

--- a/src/adapt.js
+++ b/src/adapt.js
@@ -26,8 +26,8 @@ export function getWhite (name) {
 
 /**
  * Adapt XYZ from white point W1 to W2
- * @param {White} W1
- * @param {White} W2
+ * @param {White | string} W1
+ * @param {White | string} W2
  * @param {[number, number, number]} XYZ
  * @param {{ method?: string | undefined }} options
  * @returns {[number, number, number]}

--- a/src/clone.js
+++ b/src/clone.js
@@ -1,9 +1,10 @@
 // Type "imports"
+/** @typedef {import("./color.js").default} Color */
 /** @typedef {import("./types.js").PlainColorObject} PlainColorObject */
 
 /**
  *
- * @param {PlainColorObject} color
+ * @param {Color | PlainColorObject} color
  * @returns {PlainColorObject}
  */
 export default function clone (color) {

--- a/src/clone.js
+++ b/src/clone.js
@@ -1,16 +1,16 @@
 // Type "imports"
 /** @typedef {import("./color.js").default} Color */
+/** @typedef {import("./types.js").Coords} Coords */
 /** @typedef {import("./types.js").PlainColorObject} PlainColorObject */
 
 /**
- *
- * @param {Color | PlainColorObject} color
+ * @param {PlainColorObject} color
  * @returns {PlainColorObject}
  */
 export default function clone (color) {
 	return {
 		space: color.space,
-		coords: /** @type {[number, number, number]} */ (color.coords.slice()),
+		coords: /** @type {Coords} */ (color.coords.slice()),
 		alpha: color.alpha,
 	};
 }

--- a/src/clone.js
+++ b/src/clone.js
@@ -9,7 +9,7 @@
 export default function clone (color) {
 	return {
 		space: color.space,
-		coords: color.coords.slice(),
+		coords: /** @type {[number, number, number]} */ (color.coords.slice()),
 		alpha: color.alpha,
 	};
 }

--- a/src/deltaE.js
+++ b/src/deltaE.js
@@ -10,7 +10,7 @@ import deltaEMethods from "./deltaE/index.js";
  *
  * @param {ColorTypes} c1
  * @param {ColorTypes} c2
- * @param {Methods | ({ method: Methods } & Record<string, any>)} o
+ * @param {Methods | ({ method?: Methods | undefined } & Record<string, any>)} [o]
  * deltaE method to use as well as any other options to pass to the deltaE function
  * @returns {number}
  * @throws {TypeError} Unknown or unspecified method

--- a/src/deltaE/deltaEHCT.js
+++ b/src/deltaE/deltaEHCT.js
@@ -2,13 +2,16 @@ import hct from "../spaces/hct.js";
 import {viewingConditions} from "../spaces/hct.js";
 import getColor from "../getColor.js";
 
+// Type "imports"
+/** @typedef {import("../types.js").Coords} Coords */
+
 const rad2deg = 180 / Math.PI;
 const deg2rad = Math.PI / 180;
 const ucsCoeff = [1.00, 0.007, 0.0228];
 
 /**
 * Convert HCT chroma and hue (CAM16 JMh colorfulness and hue) using UCS logic for a and b.
-* @param {number[]} coords - HCT coordinates.
+* @param {Coords} coords - HCT coordinates.
 * @return {number[]}
 */
 function convertUcsAb (coords) {

--- a/src/deltas.js
+++ b/src/deltas.js
@@ -13,10 +13,7 @@ import { isNone } from "./util.js";
  * @param {ColorTypes} c2
  * @param {object} options
  * @param {string | ColorSpace} [options.space=c1.space] - The color space to use for the delta calculation. Defaults to the color space of the first color.
- * @param {string} [options.hue="shorter"] - How to handle hue differences. Same as hue interpolation option.
- * @returns {number[]} - An array of differences per component.
- * 		If one of the components is none, the difference will be 0.
- * 		If both components are none, the difference will be none.
+ * @param {Parameters<typeof adjust>[0]} [options.hue="shorter"] - How to handle hue differences. Same as hue interpolation option.
  */
 export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 	c1 = getColor(c1);
@@ -27,7 +24,7 @@ export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 	[c1, c2] = [c1, c2].map(c => to(c, space));
 	let [coords1, coords2] = [c1, c2].map(c => c.coords);
 
-	let coords = coords1.map((coord1, i) => {
+	let coords = /** @type {[number, number, number]} */ (coords1.map((coord1, i) => {
 		let coordMeta = spaceCoords[i];
 		let coord2 = coords2[i];
 
@@ -36,11 +33,11 @@ export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 		}
 
 		return subtractCoords(coord1, coord2);
-	});
+	}));
 
 	let alpha = subtractCoords(c1.alpha, c2.alpha);
 
-	return { space: c1.space, spaceId: c1.space.id, coords, alpha };
+	return { space: c1.space, spaceId: ColorSpace.get(c1.space).id, coords, alpha };
 }
 
 function subtractCoords (c1, c2) {

--- a/src/display.js
+++ b/src/display.js
@@ -3,14 +3,15 @@ import defaults from "./defaults.js";
 import to from "./to.js";
 import serialize from "./serialize.js";
 import clone from "./clone.js";
+import getColor from "./getColor.js";
 import REC2020 from "./spaces/rec2020.js";
 import P3 from "./spaces/p3.js";
 import Lab from "./spaces/lab.js";
 import sRGB from "./spaces/srgb.js";
-import Color from "./color.js";
 
 // Type "imports"
 /** @typedef {import("./types.js").ColorTypes} ColorTypes */
+/** @typedef {import("./types.js").PlainColorObject} PlainColorObject */
 /** @typedef {import("./types.js").Display} Display */
 /** @typedef {import("./ColorSpace.js").default} ColorSpace */
 
@@ -45,17 +46,17 @@ if (typeof CSS !== "undefined" && CSS.supports) {
  * with a color property containing the converted color (or the original, if no conversion was necessary)
  */
 export default function display (color, {space = defaults.display_space, ...options} = {}) {
-	color = Color.get(color);
+	color = getColor(color);
 
 	let ret = /** @type {Display} */ (serialize(color, options));
 
 	if (typeof CSS === "undefined" || CSS.supports("color", /** @type {string} */ (ret)) || !defaults.display_space) {
 		ret = /** @type {Display} */ (new String(ret));
-		ret.color = color;
+		ret.color = /** @type {PlainColorObject} */ (color);
 	}
 	else {
 		// If we're here, what we were about to output is not supported
-		let fallbackColor = color;
+		let fallbackColor = /** @type {PlainColorObject} */ (color);
 
 		// First, check if the culprit is none values
 		let hasNone = color.coords.some(isNone) || isNone(color.alpha);
@@ -64,7 +65,7 @@ export default function display (color, {space = defaults.display_space, ...opti
 			// Does the browser support none values?
 			if (!(supportsNone ??= CSS.supports("color", "hsl(none 50% 50%)"))) {
 				// Nope, try again without none
-				fallbackColor = clone(/** @type {Color} */ (color));
+				fallbackColor = clone(/** @type {PlainColorObject} */ (color));
 				fallbackColor.coords = /** @type {[number, number, number]} */ (fallbackColor.coords.map(skipNone));
 				fallbackColor.alpha = skipNone(fallbackColor.alpha);
 

--- a/src/display.js
+++ b/src/display.js
@@ -7,6 +7,7 @@ import REC2020 from "./spaces/rec2020.js";
 import P3 from "./spaces/p3.js";
 import Lab from "./spaces/lab.js";
 import sRGB from "./spaces/srgb.js";
+import Color from "./color.js";
 
 // Type "imports"
 /** @typedef {import("./types.js").ColorTypes} ColorTypes */
@@ -44,10 +45,12 @@ if (typeof CSS !== "undefined" && CSS.supports) {
  * with a color property containing the converted color (or the original, if no conversion was necessary)
  */
 export default function display (color, {space = defaults.display_space, ...options} = {}) {
-	let ret = serialize(color, options);
+	color = Color.get(color);
 
-	if (typeof CSS === "undefined" || CSS.supports("color", ret) || !defaults.display_space) {
-		ret = new String(ret);
+	let ret = /** @type {Display} */ (serialize(color, options));
+
+	if (typeof CSS === "undefined" || CSS.supports("color", /** @type {string} */ (ret)) || !defaults.display_space) {
+		ret = /** @type {Display} */ (new String(ret));
 		ret.color = color;
 	}
 	else {
@@ -61,15 +64,16 @@ export default function display (color, {space = defaults.display_space, ...opti
 			// Does the browser support none values?
 			if (!(supportsNone ??= CSS.supports("color", "hsl(none 50% 50%)"))) {
 				// Nope, try again without none
-				fallbackColor = clone(color);
+				fallbackColor = clone(/** @type {Color} */ (color));
 				fallbackColor.coords = /** @type {[number, number, number]} */ (fallbackColor.coords.map(skipNone));
 				fallbackColor.alpha = skipNone(fallbackColor.alpha);
 
+				// @ts-expect-error This is set to the correct type later
 				ret = serialize(fallbackColor, options);
 
-				if (CSS.supports("color", ret)) {
+				if (CSS.supports("color", /** @type {string} */ (ret))) {
 					// We're done, now it's supported
-					ret = new String(ret);
+					ret = /** @type {Display} */ (new String(ret));
 					ret.color = fallbackColor;
 					return ret;
 				}
@@ -79,7 +83,7 @@ export default function display (color, {space = defaults.display_space, ...opti
 		// If we're here, the color function is not supported
 		// Fall back to fallback space
 		fallbackColor = to(fallbackColor, space);
-		ret = new String(serialize(fallbackColor, options));
+		ret = /** @type {Display} */ (new String(serialize(fallbackColor, options)));
 		ret.color = fallbackColor;
 	}
 

--- a/src/display.js
+++ b/src/display.js
@@ -62,7 +62,7 @@ export default function display (color, {space = defaults.display_space, ...opti
 			if (!(supportsNone ??= CSS.supports("color", "hsl(none 50% 50%)"))) {
 				// Nope, try again without none
 				fallbackColor = clone(color);
-				fallbackColor.coords = fallbackColor.coords.map(skipNone);
+				fallbackColor.coords = /** @type {[number, number, number]} */ (fallbackColor.coords.map(skipNone));
 				fallbackColor.alpha = skipNone(fallbackColor.alpha);
 
 				ret = serialize(fallbackColor, options);

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -44,7 +44,7 @@ export class Hooks {
 	 * This will also be used as the function context, unless it has a `context` property,
 	 * in which case that is used as the function context
 	 */
-	run (name: string, env?: { context?: Record<string, any> }): void;
+	run (name: string, env?: { context?: Record<string, any> } & Record<string, any>): void;
 }
 
 declare const hooks: Hooks;

--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -20,6 +20,7 @@ import deltaE from "./deltaE.js";
 /** @typedef {import("./types.js").Range} Range */
 /** @typedef {import("./types.js").RangeOptions} RangeOptions */
 /** @typedef {import("./types.js").StepsOptions} StepsOptions */
+/** @typedef {import("./types.js").Ref} Ref  */
 
 /**
  * Return an intermediate color between two colors
@@ -192,7 +193,7 @@ export function range (color1, color2, options = {}) {
 	if (space.coords.h && space.coords.h.type === "angle") {
 		let arc = options.hue = options.hue || "shorter";
 
-		let hue = [space, "h"];
+		let /** @type {Ref} */ hue = [space, "h"];
 		let [θ1, θ2] = [get(color1, hue), get(color2, hue)];
 		// Undefined hues must be evaluated before hue fix-up to properly
 		// calculate hue arcs between undefined and defined hues.

--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -210,8 +210,8 @@ export function range (color1, color2, options = {}) {
 
 	if (premultiplied) {
 		// not coping with polar spaces yet
-		color1.coords = color1.coords.map(c => c * color1.alpha);
-		color2.coords = color2.coords.map(c => c * color2.alpha);
+		color1.coords = /** @type {[number, number, number]} */ (color1.coords.map(c => c * color1.alpha));
+		color2.coords = /** @type {[number, number, number]} */ (color2.coords.map(c => c * color2.alpha));
 	}
 
 	return Object.assign(p => {

--- a/src/multiply-matrices.js
+++ b/src/multiply-matrices.js
@@ -9,7 +9,7 @@ export default function multiplyMatrices (A, B) {
 
 	if (!Array.isArray(A[0])) {
 		// A is vector, convert to [[a, b, c, ...]]
-		A = [A];
+		A = [/** @type {number[]} */ (A)];
 	}
 
 	if (!Array.isArray(B[0])) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -175,8 +175,10 @@ export const regex = {
  * @returns {{value: number, meta: ArgumentMeta}}
  */
 export function parseArgument (rawArg) {
+	/** @type {Partial<ArgumentMeta>} */
 	let meta = {};
 	let unit = rawArg.match(regex.unitValue)?.[0];
+	/** @type {string | number} */
 	let value = meta.raw = rawArg;
 
 	if (unit) { // It’s a dimension token
@@ -202,7 +204,7 @@ export function parseArgument (rawArg) {
 		meta.type = "<ident>";
 	}
 
-	return { value, meta };
+	return { value: /** @type {number} */ (value), meta: /** @type {ArgumentMeta} */ (meta) };
 }
 
 /**

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -94,6 +94,7 @@ export default function serialize (color, options = {}) {
 		}
 
 		// Serialize alpha?
+		/** @type {string | number} */
 		let alpha = color.alpha;
 
 		if (alphaFormat !== undefined && !(typeof alphaFormat === "object")) {

--- a/src/space-accessors.js
+++ b/src/space-accessors.js
@@ -36,7 +36,7 @@ function addSpaceAccessors (id, space) {
 
 			// Enable color.spaceId.coordName syntax
 			return new Proxy(ret, {
-				has: (obj, property) => {
+				has: /** @param {string} property */ (obj, property) => {
 					try {
 						ColorSpace.resolveCoord([space, property]);
 						return true;
@@ -58,7 +58,7 @@ function addSpaceAccessors (id, space) {
 				},
 				set: (obj, property, value, receiver) => {
 					if (property && typeof property !== "symbol" && !(property in obj) || property >= 0) {
-						let {index} = ColorSpace.resolveCoord([space, property]);
+						let {index} = ColorSpace.resolveCoord([space, /** @type {string} */ (property)]);
 
 						if (index >= 0) {
 							obj[index] = value;

--- a/src/spaces/cam16.js
+++ b/src/spaces/cam16.js
@@ -52,10 +52,10 @@ const deg2rad = Math.PI / 180;
  * @returns {[number, number, number]}
  */
 export function adapt (coords, fl) {
-	const temp = coords.map(c => {
+	const temp = /** @type {[number, number, number]} */ (coords.map(c => {
 		const x = spow(fl * Math.abs(c) * 0.01, adaptedCoef);
 		return 400 * copySign(x, c) / (x + 27.13);
-	});
+	}));
 	return temp;
 }
 
@@ -66,10 +66,10 @@ export function adapt (coords, fl) {
  */
 export function unadapt (adapted, fl) {
 	const constant = 100 / fl * (27.13 ** adaptedCoefInv);
-	return adapted.map(c => {
+	return /** @type {[number, number, number]} */ (adapted.map(c => {
 		const cabs = Math.abs(c);
 		return copySign(constant * spow(cabs / (400 - cabs), adaptedCoefInv), c);
-	});
+	}));
 }
 
 /**
@@ -174,9 +174,9 @@ export function environment (
 	});
 
 	// Achromatic response
-	const rgbCW = rgbW.map((c, i) => {
+	const rgbCW = /** @type {[number, number, number]} */ (rgbW.map((c, i) => {
 		return c * env.dRgb[i];
-	});
+	}));
 	const rgbAW = adapt(rgbCW, env.fl);
 	env.aW = env.nbb * (2 * rgbAW[0] + rgbAW[1] + 0.05 * rgbAW[2]);
 
@@ -278,19 +278,20 @@ export function fromCam16 (cam16, env) {
 
 	// Calculate back from cone response to XYZ
 	const rgb_c = unadapt(
-		multiplyMatrices(m1, [p2, a, b]).map(c => {
+		/** @type {[number, number, number]} */
+		(multiplyMatrices(m1, [p2, a, b]).map(c => {
 			return c * 1 / 1403;
-		}),
+		})),
 		env.fl,
 	);
-	return multiplyMatrices(
+	return /** @type {[number, number, number]} */ (multiplyMatrices(
 		cat16Inv,
 		rgb_c.map((c, i) => {
 			return c * env.dRgbInv[i];
 		}),
 	).map(c => {
 		return c / 100;
-	});
+	}));
 }
 
 /**
@@ -305,9 +306,10 @@ export function toCam16 (xyzd65, env) {
 		return c * 100;
 	});
 	const rgbA = adapt(
-		multiplyMatrices(cat16, xyz100).map((c, i) => {
+		/** @type {[number, number, number]} */
+		(multiplyMatrices(cat16, xyz100).map((c, i) => {
 			return c * env.dRgb[i];
-		}),
+		})),
 		env.fl,
 	);
 

--- a/src/spaces/cam16.js
+++ b/src/spaces/cam16.js
@@ -141,6 +141,7 @@ export function environment (
 	const rgbW = multiplyMatrices(cat16, xyzW);
 
 	// Surround: dark, dim, and average
+	// @ts-expect-error surround is never used again
 	surround = surroundMap[env.surround];
 	const f = surround[0];
 	env.c = surround[1];

--- a/src/spaces/hpluv.js
+++ b/src/spaces/hpluv.js
@@ -114,7 +114,7 @@ export default new ColorSpace({
 		}
 		else {
 			let lines = calculateBoundingLines(l);
-			let max = calcMaxChromaHpluv(lines, h);
+			let max = calcMaxChromaHpluv(lines);
 			c = max / 100 * s;
 		}
 

--- a/src/spaces/luv.js
+++ b/src/spaces/luv.js
@@ -33,7 +33,7 @@ export default new ColorSpace({
 	// Convert D65-adapted XYZ to Luv
 	// https://en.wikipedia.org/wiki/CIELUV#The_forward_transformation
 	fromBase (XYZ) {
-		let xyz = [skipNone(XYZ[0]), skipNone(XYZ[1]), skipNone(XYZ[2])];
+		let xyz = /** @type {[number, number, number]} */ ([skipNone(XYZ[0]), skipNone(XYZ[1]), skipNone(XYZ[2])]);
 		let y = xyz[1];
 
 		let [up, vp] = uv({space: xyz_d65, coords: xyz});

--- a/src/spaces/okhsl.js
+++ b/src/spaces/okhsl.js
@@ -158,7 +158,7 @@ function getStMid (a, b) {
 
 /**
  * @param {number[]} lab
- * @param {number[]} lmsToRgb
+ * @param {number[][]} lmsToRgb
  */
 export function oklabToLinearRGB (lab, lmsToRgb) {
 	// Convert from Oklab to linear RGB.
@@ -175,8 +175,8 @@ export function oklabToLinearRGB (lab, lmsToRgb) {
 }
 
 /**
- * @param {[number, number]} a
- * @param {[number, number]} b
+ * @param {number} a
+ * @param {number} b
  * @param {number[][]} lmsToRgb
  * @param {number[][]} okCoeff
  * @returns {[number, number]}

--- a/src/spaces/okhsl.js
+++ b/src/spaces/okhsl.js
@@ -157,8 +157,8 @@ function getStMid (a, b) {
 }
 
 /**
- * @param {number[][]} lab
- * @param {number[][]} lmsToRgb
+ * @param {number[]} lab
+ * @param {number[]} lmsToRgb
  */
 export function oklabToLinearRGB (lab, lmsToRgb) {
 	// Convert from Oklab to linear RGB.

--- a/src/spaces/srgb.js
+++ b/src/spaces/srgb.js
@@ -89,7 +89,7 @@ export default new RGBColorSpace({
 					coords.push(alpha);
 				}
 
-				coords = coords.map(c => Math.round(c * 255));
+				coords = /** @type {[number, number, number]} */ (coords.map(c => Math.round(c * 255)));
 
 				let collapsible = collapse && coords.every(c => c % 17 === 0);
 

--- a/src/spaces/srgb.js
+++ b/src/spaces/srgb.js
@@ -2,6 +2,9 @@ import RGBColorSpace from "../RGBColorSpace.js";
 import sRGBLinear from "./srgb-linear.js";
 import KEYWORDS from "../keywords.js";
 
+// Type "imports"
+/** @typedef {import("../types.js").Coords} Coords */
+
 let coordGrammar = Array(3).fill("<percentage> | <number>[0, 255]");
 let coordGrammarNumber = Array(3).fill("<number>[0, 255]");
 
@@ -70,6 +73,7 @@ export default new RGBColorSpace({
 					str = str.replace(/[a-f0-9]/gi, "$&$&");
 				}
 
+				/** @type {number[]} */
 				let rgba = [];
 				str.replace(/[a-f0-9]{2}/gi, component => {
 					rgba.push(parseInt(component, 16) / 255);
@@ -77,8 +81,8 @@ export default new RGBColorSpace({
 
 				return {
 					spaceId: "srgb",
-					coords: rgba.slice(0, 3),
-					alpha: rgba.slice(3)[0],
+					coords: /** @type {Coords} */ (rgba.slice(0, 3)),
+					alpha: /** @type {number} */ (rgba.slice(3)[0]),
 				};
 			},
 			serialize: (coords, alpha, {

--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -60,6 +60,11 @@ const GMAPPRESET = {
  * @param {string} [space]
  * @returns {PlainColorObject}
  */
+/**
+ * @param {ColorTypes} color
+ * @param {string & Partial<ToGamutOptions> | ToGamutOptions} [space]
+ * @returns {PlainColorObject}
+ */
 export default function toGamut (
 	color,
 	{
@@ -87,7 +92,7 @@ export default function toGamut (
 	// mapSpace: space with the coord we're reducing
 
 	if (inGamut(color, space, { epsilon: 0 })) {
-		return color;
+		return /** @type {PlainColorObject} */ (color);
 	}
 
 	let spaceColor;
@@ -199,18 +204,21 @@ export default function toGamut (
 	}
 
 	color.coords = spaceColor.coords;
-	return color;
+	return /** @type {PlainColorObject} */ (color);
 }
 
 /** @type {"color"} */
 toGamut.returns = "color";
 
-// The reference colors to be used if lightness is out of the range 0-1 in the
-// `Oklch` space. These are created in the `Oklab` space, as it is used by the
-// DeltaEOK calculation, so it is guaranteed to be imported.
+/**
+ * The reference colors to be used if lightness is out of the range 0-1 in the
+ * `Oklch` space. These are created in the `Oklab` space, as it is used by the
+ * DeltaEOK calculation, so it is guaranteed to be imported.
+ * @satisfies {Record<string, ColorTypes>}
+ */
 const COLORS = {
-	WHITE: { space: oklab, coords: [1, 0, 0] },
-	BLACK: { space: oklab, coords: [0, 0, 0] },
+	WHITE: { space: oklab, coords: [1, 0, 0], alpha: 1 },
+	BLACK: { space: oklab, coords: [0, 0, 0], alpha: 1 },
 };
 
 /**
@@ -260,7 +268,7 @@ export function toGamutCSS (origin, {space} = {}) {
 
 	function clip (_color) {
 		const destColor = to(_color, space);
-		const spaceCoords = Object.values(space.coords);
+		const spaceCoords = Object.values(/** @type {ColorSpace} */ (space).coords);
 		destColor.coords = /** @type {[number, number, number]} */ (destColor.coords.map((coord, index) => {
 			if ("range" in spaceCoords[index]) {
 				const [min, max] =  spaceCoords[index].range;

--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -178,7 +178,7 @@ export default function toGamut (
 		) {
 			let bounds = Object.values(space.coords).map(c => c.range || []);
 
-			spaceColor.coords = spaceColor.coords.map((c, i) => {
+			spaceColor.coords = /** @type {[number, number, number]} */ (spaceColor.coords.map((c, i) => {
 				let [min, max] = bounds[i];
 
 				if (min !== undefined) {
@@ -190,7 +190,7 @@ export default function toGamut (
 				}
 
 				return c;
-			});
+			}));
 		}
 	}
 
@@ -261,13 +261,13 @@ export function toGamutCSS (origin, {space} = {}) {
 	function clip (_color) {
 		const destColor = to(_color, space);
 		const spaceCoords = Object.values(space.coords);
-		destColor.coords = destColor.coords.map((coord, index) => {
+		destColor.coords = /** @type {[number, number, number]} */ (destColor.coords.map((coord, index) => {
 			if ("range" in spaceCoords[index]) {
 				const [min, max] =  spaceCoords[index].range;
 				return util.clamp(min, coord, max);
 			}
 			return coord;
-		});
+		}));
 		return destColor;
 	}
 	let min = 0;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -99,6 +99,7 @@ export interface ParseFunctionReturn {
 	lastAlpha: boolean;
 	rawName: string;
 	rawArgs: string;
+	commas: boolean;
 }
 
 // rgbspace.js

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -126,7 +126,15 @@ export interface SerializeOptions {
 	/** Coordinate format to override the default */
 	coords?: Coords | undefined;
 	/** Alpha format */
-	alpha?: "<number>" | "<percentage>" | boolean | { type: "<number>" | "<percentage>"; include: boolean } | undefined;
+	alpha?:
+		| "<number>"
+		| "<percentage>"
+		| boolean
+		| {
+			type?: "<number>" | "<percentage>" | undefined;
+			include?: boolean | undefined;
+		  }
+		| undefined;
 	/**
 	 * Force commas as a separator
 	 * @default false
@@ -156,7 +164,7 @@ export interface ToGamutOptions {
 	method?: "css" | "clip" | (string & {}) | undefined;
 	/** The color whose space is being mapped to. Defaults to the current space */
 	space?: string | ColorSpace | undefined;
-	deltaEMethod?: Methods | undefined;
+	deltaEMethod?: Methods | "" | undefined;
 	/** The "just noticeable difference" to target */
 	jnd?: number | undefined;
 	/**

--- a/src/variations.js
+++ b/src/variations.js
@@ -4,6 +4,7 @@ import set from "./set.js";
 // Type "imports"
 /** @typedef {import("./types.js").ColorTypes} ColorTypes */
 /** @typedef {import("./types.js").PlainColorObject} PlainColorObject */
+/** @typedef {import("./types.js").Ref} Ref */
 
 /**
  * @param {ColorTypes} color
@@ -12,7 +13,7 @@ import set from "./set.js";
  */
 export function lighten (color, amount = 0.25) {
 	let space = ColorSpace.get("oklch", "lch");
-	let lightness = [space, "l"];
+	let /** @type {Ref} */ lightness = [space, "l"];
 	return set(color, lightness, l => l * (1 + amount));
 }
 
@@ -23,6 +24,6 @@ export function lighten (color, amount = 0.25) {
  */
 export function darken (color, amount = .25) {
 	let space = ColorSpace.get("oklch", "lch");
-	let lightness = [space, "l"];
+	let /** @type {Ref} */ lightness = [space, "l"];
 	return set(color, lightness, l => l * (1 - amount));
 }


### PR DESCRIPTION
Closes #572

Fixes type errors originating from the codebase itself.

In some instances, the logic was changed where it seemed like the type error reflected an actual problem. For example, adding `color = Color.get(color)` where the signature made it seem as though a function could take `ColorTypes`, but actually couldn't.