### PR TITLE
[types] overload multiplyMatrices types

### DIFF
--- a/src/CATs.js
+++ b/src/CATs.js
@@ -31,7 +31,7 @@ export function defineCAT (/** @type {CAT} */ {id, toCone_M, fromCone_M}) {
  * @param {White} W1
  * @param {White} W2
  * @param {string} id
- * @returns {number[]}
+ * @returns {number[][]}
  */
 export function adapt (W1, W2, id = "Bradford") {
 	// adapt from a source whitepoint or illuminant W1

--- a/src/adapt.js
+++ b/src/adapt.js
@@ -70,7 +70,7 @@ export default function adapt (W1, W2, XYZ, options = {}) {
 	hooks.run("chromatic-adaptation-end", env);
 
 	if (env.M) {
-		return /** @type {[number, number, number]} */ (multiplyMatrices(env.M, env.XYZ));
+		return /** @type {[number, number, number]} */ (multiplyMatrices(/** @type {number[][]}*/ (env.M), env.XYZ));
 	}
 	else {
 		throw new TypeError("Only Bradford CAT with white points D50 and D65 supported for now.");

--- a/src/multiply-matrices.js
+++ b/src/multiply-matrices.js
@@ -5,12 +5,12 @@
  * - A becomes 1 x n
  * - B becomes n x 1
  *
- * Returns Matrix m x p or equivalent array or value
+ * Returns Matrix m x p or equivalent array
  *
  * @overload
  * @param {number[]} A Vector 1 x n
  * @param {number[]} B Vector n x 1
- * @returns {number} Value
+ * @returns {number[]} Array with length 1
  *
  * @overload
  * @param {number[][]} A Matrix m x n
@@ -18,8 +18,8 @@
  * @returns {number[]} Array with length m
  *
  * @overload
- * @param {number[]} A vector 1 x n
- * @param {number[][]} B vector n x p
+ * @param {number[]} A Vector 1 x n
+ * @param {number[][]} B Matrix n x p
  * @returns {number[]} Array with length p
  *
  * @overload
@@ -29,7 +29,7 @@
  *
  * @param {number[] | number[][]} A Matrix m x n or a vector
  * @param {number[] | number[][]} B Matrix n x p or a vector
- * @returns {number | number[] | number[][]} Matrix m x p or equivalent array or value
+ * @returns {number[] | number[][]} Matrix m x p or equivalent array
  */
 export default function multiplyMatrices (A, B) {
 	let m = A.length;
@@ -77,13 +77,10 @@ export default function multiplyMatrices (A, B) {
 	}));
 
 	if (m === 1) {
-		product = product[0]; // Avoid [[a, b, c, ...]] and [[a]]
+		product = product[0]; // Avoid [[a, b, c, ...]]
 	}
 	if (p === 1) {
-		if (m === 1) {
-			return product[0]; // Avoid [a]
-		}
-		product = product.map(x => x[0]); // Avoid [[a], [b], [c], ...]]
+		return product.map(x => x[0]); // Avoid [[a], [b], [c], ...]]
 	}
 
 	return product;

--- a/src/multiply-matrices.js
+++ b/src/multiply-matrices.js
@@ -1,25 +1,64 @@
 /**
  * A is m x n. B is n x p. product is m x p.
+ *
+ * Array arguments are treated like vectors:
+ * - A becomes 1 x n
+ * - B becomes n x 1
+ *
+ * Returns Matrix m x p or equivalent array or value
+ *
+ * @overload
+ * @param {number[]} A Vector 1 x n
+ * @param {number[]} B Vector n x 1
+ * @returns {number} Value
+ *
+ * @overload
+ * @param {number[][]} A Matrix m x n
+ * @param {number[]} B Vector n x 1
+ * @returns {number[]} Array with length m
+ *
+ * @overload
+ * @param {number[]} A vector 1 x n
+ * @param {number[][]} B vector n x p
+ * @returns {number[]} Array with length p
+ *
+ * @overload
+ * @param {number[][]} A Matrix m x n
+ * @param {number[][]} B Matrix n x p
+ * @returns {number[][]} Matrix m x p
+ *
  * @param {number[] | number[][]} A Matrix m x n or a vector
  * @param {number[] | number[][]} B Matrix n x p or a vector
- * @returns {number[]} Matrix m x p
+ * @returns {number | number[] | number[][]} Matrix m x p or equivalent array or value
  */
 export default function multiplyMatrices (A, B) {
 	let m = A.length;
+	/** @type {number[][]} */
+	let AM;
+	/** @type {number[][]} */
+	let BM;
 
 	if (!Array.isArray(A[0])) {
 		// A is vector, convert to [[a, b, c, ...]]
-		A = [/** @type {number[]} */ (A)];
+		AM = [/** @type {number[]} */ (A)];
+	}
+	else {
+		AM = /** @type {number[][]} */ (A);
 	}
 
 	if (!Array.isArray(B[0])) {
 		// B is vector, convert to [[a], [b], [c], ...]]
-		B = B.map(x => [x]);
+		BM = B.map(x => [x]);
+	}
+	else {
+		BM = /** @type {number[][]} */ (B);
 	}
 
-	let p = B[0].length;
-	let B_cols = B[0].map((_, i) => B.map(x => x[i])); // transpose B
-	let product = A.map(row => B_cols.map(col => {
+
+	let p = BM[0].length;
+	let BM_cols = BM[0].map((_, i) => BM.map(x => x[i])); // transpose B
+	/** @type {number[] | number[][]} */
+	let product = AM.map(row => BM_cols.map(col => {
 		let ret = 0;
 
 		if (!Array.isArray(row)) {
@@ -38,11 +77,13 @@ export default function multiplyMatrices (A, B) {
 	}));
 
 	if (m === 1) {
-		product = product[0]; // Avoid [[a, b, c, ...]]
+		product = product[0]; // Avoid [[a, b, c, ...]] and [[a]]
 	}
-
 	if (p === 1) {
-		return product.map(x => x[0]); // Avoid [[a], [b], [c], ...]]
+		if (m === 1) {
+			return product[0]; // Avoid [a]
+		}
+		product = product.map(x => x[0]); // Avoid [[a], [b], [c], ...]]
 	}
 
 	return product;

--- a/types/test/multiply-matrices.ts
+++ b/types/test/multiply-matrices.ts
@@ -5,8 +5,13 @@ multiplyMatrices();
 // @ts-expect-error
 multiplyMatrices([1, 2, 3]);
 
-multiplyMatrices([1, 2, 3], [4, 5, 6]); // $ExpectType number[]
-// $ExpectType number[]
+multiplyMatrices([1, 2, 3], [4, 5, 6]); // $ExpectType number
+
+multiplyMatrices([1, 2, 3], [[4, 5], [6, 7], [8, 9]]); // $ExpectType number[]
+
+multiplyMatrices([[1, 2], [3, 4]], [5, 6]); // $ExpectType number[]
+
+// $ExpectType number[][]
 multiplyMatrices(
 	[
 		[1, 2, 3],

--- a/types/test/multiply-matrices.ts
+++ b/types/test/multiply-matrices.ts
@@ -5,7 +5,7 @@ multiplyMatrices();
 // @ts-expect-error
 multiplyMatrices([1, 2, 3]);
 
-multiplyMatrices([1, 2, 3], [4, 5, 6]); // $ExpectType number
+multiplyMatrices([1, 2, 3], [4, 5, 6]); // $ExpectType number[]
 
 multiplyMatrices([1, 2, 3], [[4, 5], [6, 7], [8, 9]]); // $ExpectType number[]
 


### PR DESCRIPTION
Adds overloads for the parameter and return types of multiplyMatrices. And tests in `types/test` for the overloads.

Includes updates to `adapt.js` and `CATs.js` to fix type errors due to the new overloaded types.

~I was probably a bit too overzealous and added functionality for returning a number result as well. 
Let me know if this new functionality should be in a separate pull request.~ Removed to add in future.

@MysteryBlokHed, hopefully I didn't step on any in-progress type fixes.