### PR TITLE
Do not use HSL normalized saturation and hue for certain spaces

### DIFF
--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -1,61 +1,6 @@
 import ColorSpace from "../ColorSpace.js";
 import sRGB from "./srgb.js";
 
-/**
- * @param {[number, number, number]} rgb
- * @returns {[number, number, number]}
- */
-export function rgbToHsl (rgb) {
-	let max = Math.max(...rgb);
-	let min = Math.min(...rgb);
-	let [r, g, b] = rgb;
-	let [h, s, l] = [null, 0, (min + max) / 2];
-	let d = max - min;
-
-	if (d !== 0) {
-		s = (l === 0 || l === 1) ? 0 : (max - l) / Math.min(l, 1 - l);
-
-		switch (max) {
-			case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-			case g: h = (b - r) / d + 2; break;
-			case b: h = (r - g) / d + 4;
-		}
-
-		h = h * 60;
-	}
-
-	if (h >= 360) {
-		h -= 360;
-	}
-
-	return [h, s * 100, l * 100];
-}
-
-/**
- * @param {[number, number, number]} hsl
- * @returns {[number, number, number]}
- */
-export function hslToRgb (hsl) {
-	let [h, s, l] = hsl;
-	h = h % 360;
-
-	if (h < 0) {
-		h += 360;
-	}
-
-	s /= 100;
-	l /= 100;
-
-	function f (n) {
-		let k = (n + h / 30) % 12;
-		let a = s * Math.min(l, 1 - l);
-		return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
-	}
-
-	return [f(0), f(8), f(4)];
-}
-
-
 export default new ColorSpace({
 	id: "hsl",
 	name: "HSL",
@@ -79,7 +24,23 @@ export default new ColorSpace({
 
 	// Adapted from https://drafts.csswg.org/css-color-4/better-rgbToHsl.js
 	fromBase: rgb => {
-		let [h, s, l] = rgbToHsl(rgb);
+		let max = Math.max(...rgb);
+		let min = Math.min(...rgb);
+		let [r, g, b] = rgb;
+		let [h, s, l] = [null, 0, (min + max) / 2];
+		let d = max - min;
+
+		if (d !== 0) {
+			s = (l === 0 || l === 1) ? 0 : (max - l) / Math.min(l, 1 - l);
+
+			switch (max) {
+				case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+				case g: h = (b - r) / d + 2; break;
+				case b: h = (r - g) / d + 4;
+			}
+
+			h = h * 60;
+		}
 
 		// Very out of gamut colors can produce negative saturation
 		// If so, just rotate the hue by 180 and use a positive saturation
@@ -93,12 +54,28 @@ export default new ColorSpace({
 			h -= 360;
 		}
 
-		return [h, s, l];
+		return [h, s * 100, l * 100];
 	},
 
 	// Adapted from https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB_alternative
 	toBase: hsl => {
-		return hslToRgb(hsl);
+		let [h, s, l] = hsl;
+		h = h % 360;
+
+		if (h < 0) {
+			h += 360;
+		}
+
+		s /= 100;
+		l /= 100;
+
+		function f (n) {
+			let k = (n + h / 30) % 12;
+			let a = s * Math.min(l, 1 - l);
+			return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+		}
+
+		return [f(0), f(8), f(4)];
 	},
 
 	formats: {

--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -1,6 +1,61 @@
 import ColorSpace from "../ColorSpace.js";
 import sRGB from "./srgb.js";
 
+/**
+ * @param {[number, number, number]} rgb
+ * @returns {[number, number, number]}
+ */
+export function rgbToHsl (rgb) {
+	let max = Math.max(...rgb);
+	let min = Math.min(...rgb);
+	let [r, g, b] = rgb;
+	let [h, s, l] = [null, 0, (min + max) / 2];
+	let d = max - min;
+
+	if (d !== 0) {
+		s = (l === 0 || l === 1) ? 0 : (max - l) / Math.min(l, 1 - l);
+
+		switch (max) {
+			case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+			case g: h = (b - r) / d + 2; break;
+			case b: h = (r - g) / d + 4;
+		}
+
+		h = h * 60;
+	}
+
+	if (h >= 360) {
+		h -= 360;
+	}
+
+	return [h, s * 100, l * 100];
+}
+
+/**
+ * @param {[number, number, number]} hsl
+ * @returns {[number, number, number]}
+ */
+export function hslToRgb (hsl) {
+	let [h, s, l] = hsl;
+	h = h % 360;
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	s /= 100;
+	l /= 100;
+
+	function f (n) {
+		let k = (n + h / 30) % 12;
+		let a = s * Math.min(l, 1 - l);
+		return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+	}
+
+	return [f(0), f(8), f(4)];
+}
+
+
 export default new ColorSpace({
 	id: "hsl",
 	name: "HSL",
@@ -24,23 +79,7 @@ export default new ColorSpace({
 
 	// Adapted from https://drafts.csswg.org/css-color-4/better-rgbToHsl.js
 	fromBase: rgb => {
-		let max = Math.max(...rgb);
-		let min = Math.min(...rgb);
-		let [r, g, b] = rgb;
-		let [h, s, l] = [null, 0, (min + max) / 2];
-		let d = max - min;
-
-		if (d !== 0) {
-			s = (l === 0 || l === 1) ? 0 : (max - l) / Math.min(l, 1 - l);
-
-			switch (max) {
-				case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-				case g: h = (b - r) / d + 2; break;
-				case b: h = (r - g) / d + 4;
-			}
-
-			h = h * 60;
-		}
+		let [h, s, l] = rgbToHsl(rgb);
 
 		// Very out of gamut colors can produce negative saturation
 		// If so, just rotate the hue by 180 and use a positive saturation
@@ -54,28 +93,12 @@ export default new ColorSpace({
 			h -= 360;
 		}
 
-		return [h, s * 100, l * 100];
+		return [h, s, l];
 	},
 
 	// Adapted from https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB_alternative
 	toBase: hsl => {
-		let [h, s, l] = hsl;
-		h = h % 360;
-
-		if (h < 0) {
-			h += 360;
-		}
-
-		s /= 100;
-		l /= 100;
-
-		function f (n) {
-			let k = (n + h / 30) % 12;
-			let a = s * Math.min(l, 1 - l);
-			return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
-		}
-
-		return [f(0), f(8), f(4)];
+		return hslToRgb(hsl);
 	},
 
 	formats: {

--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -66,7 +66,7 @@ export default new ColorSpace({
 
 		function f (n) {
 			let k = (n + h / 60) % 6;
-			return v - v * s * Math.max(0, Math.min(k, 4 - k, 1))
+			return v - v * s * Math.max(0, Math.min(k, 4 - k, 1));
 		}
 
 		return [f(5), f(3), f(1)];

--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -3,18 +3,6 @@ import sRGB from "./srgb.js";
 
 // Note that, like HSL, calculations are done directly on
 // gamma-corrected sRGB values rather than linearising them first.
-//
-// The current implementation of HSL normalizes negative saturation, and while
-// the resultant values, if used as a base for HSV conversion, are compatible
-// and will round trip well, it can often produce negative saturation in HSV for
-// out of gamut colors in HSV just due to how the HSV algorithm is defined.
-//
-// Additionally, HWB currently uses HSV as a base for conversion and, if HSL
-// negative saturation normalization is propagated through HSL -> HSV -> HWB,
-// round trip can break down as the HWB algorithm does not mathematically
-// account for such normalization. So HSV forces conversion directly through
-// sRGB and will calculate an non-normalized HSL base for conversion. HSV can
-// then be used safely as a base for HWB conversion.
 
 export default new ColorSpace({
 	id: "hsv",


### PR DESCRIPTION
The current implementation of HSL normalizes negative saturation, and while the resultant values, if used as a base for HSV conversion, are compatible and will round trip well, it can often produce negative saturation in HSV for out of gamut colors in HSV just due to how the HSV algorithm is defined.

Additionally, HWB currently uses HSV as a base for conversion and, if HSL negative saturation normalization is propagated through HSL -> HSV -> HWB, round trip can break down as the HWB algorithm does not mathematically account for such normalization.

HSV is now calculated from sRGB directly which sidesteps the HSL hue/saturation normalization. In turn, HWB which uses HSV as the base for conversion will also not be affected by the HSL hue/saturation normalization.

https://github.com/w3c/csswg-drafts/issues/10695