### PR TITLE
Set typescript target of ES2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"target":"ES2018",
 		"checkJs": true,
 		"lib": ["DOM", "ESNext"],
 		"skipLibCheck": true,

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"target":"ES2018",
 		"module": "commonjs",
 		"lib": ["DOM", "ES2020"],
 		"noImplicitAny": true,


### PR DESCRIPTION
Typescript 5.5 added support for [regular expression syntax checking](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#regular-expression-syntax-checking). One of the checks tests if a regular expression is using features that aren't supported by the target version of ECMAScript.

Named capture groups are used in `src/Type.js` and possibly some other files so a target of ES2018 was added to `tsconfig.json`.

https://github.com/color-js/color.js/blob/cfe55d358adb6c2e23c8a897282adf42904fd32d/src/Type.js#L25
