### PR TITLE
Add color space for Linear Rec2100

### DIFF
--- a/src/space-coord-accessors.d.ts
+++ b/src/space-coord-accessors.d.ts
@@ -35,6 +35,7 @@ declare class SpaceAccessors {
 	prophoto_linear: SpaceAccessor;
 	rec2020: SpaceAccessor;
 	rec2020_linear: SpaceAccessor;
+	rec2100_linear: SpaceAccessor;
 	rec2100hlg: SpaceAccessor;
 	rec2100pq: SpaceAccessor;
 	srgb: SpaceAccessor;

--- a/src/spaces/index-fn-hdr.js
+++ b/src/spaces/index-fn-hdr.js
@@ -1,6 +1,7 @@
 export {default as Jzazbz} from "./jzazbz.js";
 export {default as JzCzHz} from "./jzczhz.js";
 export {default as ICTCP} from "./ictcp.js";
+export {default as REC_2100_Linear} from "./rec2100-linear.js";
 export {default as REC_2100_PQ} from "./rec2100-pq.js";
 export {default as REC_2100_HLG} from "./rec2100-hlg.js";
 export {default as ACEScg} from "./acescg.js";

--- a/src/spaces/rec2100-hlg.js
+++ b/src/spaces/rec2100-hlg.js
@@ -1,5 +1,5 @@
 import RGBColorSpace from "../RGBColorSpace.js";
-import REC2020Linear from "./rec2020-linear.js";
+import REC_2100_Linear from "./rec2100-linear.js";
 import {spow} from "../util.js";
 
 
@@ -15,7 +15,7 @@ export default new RGBColorSpace({
 	name: "REC.2100-HLG",
 	referred: "scene",
 
-	base: REC2020Linear,
+	base: REC_2100_Linear,
 	toBase (RGB) {
 		// given HLG encoded component in range [0, 1]
 		// return media-white relative linear-light

--- a/src/spaces/rec2100-linear.js
+++ b/src/spaces/rec2100-linear.js
@@ -1,0 +1,10 @@
+import RGBColorSpace from "../RGBColorSpace.js";
+import REC_2020_Linear from "./rec2020-linear.js";
+
+export default new RGBColorSpace({
+	id: "rec2100-linear",
+	name: "Linear REC.2100",
+	white: "D65",
+	toBase: REC_2020_Linear.toBase,
+	fromBase: REC_2020_Linear.fromBase,
+});

--- a/src/spaces/rec2100-pq.js
+++ b/src/spaces/rec2100-pq.js
@@ -1,5 +1,5 @@
 import RGBColorSpace from "../RGBColorSpace.js";
-import REC2020Linear from "./rec2020-linear.js";
+import REC_2100_Linear from "./rec2100-linear.js";
 
 const Yw = 203;	// absolute luminance of media white, cd/m²
 const n = 2610 / (2 ** 14);
@@ -14,7 +14,7 @@ export default new RGBColorSpace({
 	id: "rec2100pq",
 	cssId: "rec2100-pq",
 	name: "REC.2100-PQ",
-	base: REC2020Linear,
+	base: REC_2100_Linear,
 	toBase (RGB) {
 		// given PQ encoded component in range [0, 1]
 		// return media-white relative linear-light


### PR DESCRIPTION
Closes #443

I wasn't 100% sure if I should use the `toBase` and `fromBase` functions from Linear Rec2020 or import the matrices from Linear Rec2020 and set the `toXYZ_M` and `fromXYZ_M` options. 