### PR TITLE
Avoid style recalculation of all elements on each scroll event

### DIFF
--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -15,13 +15,13 @@ main {
 		position: absolute;
 		right: 100%;
 		height: 100%;
-		/* This is a quick fix for `fit-content` below not working anymore. */
-		min-width: 220px;
+		/* Still sorting what to use for the 3em. */
+		max-width: calc(var(--page-margin) - 3em);
+		width: max-content;
 
 		& > ul {
 			position: sticky;
 			top: 1em;
-			width: fit-content;
 		}
 	}
 

--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -11,15 +11,17 @@ main {
 	}
 
 	@media (min-width: 1480px) {
-		position: fixed;
-		top: 11rem;
-		right: calc(var(--page-width) + var(--page-margin) + 1em);
-		width: fit-content;
-		max-width: calc(var(--page-margin) - 1em);
-		margin-left: 1em;
+		/* Stretch out #toc in the margin, so it can be a container for the sticky list. */
+		position: absolute;
+		right: 100%;
+		height: 100%;
+		/* This is a quick fix for `fit-content` below not working anymore. */
+		min-width: 220px;
 
-		@supports (top: max(1em, 1px)) {
-			top: max(0em, 11rem - var(--scrolltop) * 1px);
+		& > ul {
+			position: sticky;
+			top: 1em;
+			width: fit-content;
 		}
 	}
 

--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -11,17 +11,19 @@ main {
 	}
 
 	@media (min-width: 1480px) {
+		--_gap: 1rem;
+		box-sizing: border-box;
 		/* Stretch out #toc in the margin, so it can be a container for the sticky list. */
 		position: absolute;
 		right: 100%;
 		height: 100%;
-		/* Still sorting what to use for the 3em. */
-		max-width: calc(var(--page-margin) - 3em);
+		padding-inline: var(--_gap);
+		max-width: calc(var(--page-margin) - 2 * var(--_gap));
 		width: max-content;
 
 		& > ul {
 			position: sticky;
-			top: 1em;
+			top: var(--_gap);
 		}
 	}
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -9,10 +9,5 @@ if (location.pathname.indexOf("/docs/") > -1 && window.toc) {
 	import("./docs.js");
 }
 
-let root = document.documentElement;
-
 styleCallouts();
 
-document.addEventListener("scroll", evt => {
-	root.style.setProperty("--scrolltop", root.scrollTop);
-}, {passive: true});


### PR DESCRIPTION
## Description

Addresses[ laggy scrolling](https://github.com/color-js/color.js/issues/587) resulting from unnecessary style recalculations.

The most important thing about this PR is that this listener is removed.

```js
document.addEventListener("scroll", evt => {
	root.style.setProperty("--scrolltop", root.scrollTop);
}, {passive: true});
```

Without the listener, the main thread is almost completely idle during scrolling. With the listener, the main thread is [fully occupied with tasks that take hundreds of milliseconds on lower end devices](https://github.com/color-js/color.js/issues/587#user-content-perf-during-scroll). That means scrolling at a few FPS, 100% of the time.

The only thing this listener is doing is make an element behave as though it has `position: sticky`. So the goal of the PR is to convert it to `position: sticky` and remove the need for any style recalculation.

Using `position: sticky` also has better behavior in other ways. The previous code results in the bottom items not being reachable on long lists (such as [/spaces](https://colorjs.io/docs/spaces)).

<img width=300 src='https://github.com/user-attachments/assets/caf58027-1eaa-4347-b13a-cca7829aae65' />
<img width=300 src='https://github.com/user-attachments/assets/ace3e882-6c1b-458b-95b5-846577fd1e6e' />

## Probably the best solution

The markup should probably be changed to be similar to the [/api page](https://colorjs.io/api/).

![tocoutside](https://github.com/user-attachments/assets/09d7d786-05ab-4f5c-9a0b-d2c976f53609)


For `position: sticky` to work, you need to have a container that spans the height you want the element to travel. So you'd want a container which is positioned next to the content and is equally high.


However, in the current markup the TOC element is inside of the content, so `position: sticky` cannot produce the intended effect of flowing next to the content.

![tocinside](https://github.com/user-attachments/assets/698fb55d-552e-4c24-8ff8-c0ad16367a78)

## This PRs CSS only solution

When trying out this markup change, I noticed it would cascade into too many other CSS changes and associated regression risk. I preserved [a simple attempt at modifying the markup](https://github.com/Inwerpsel/color.js/commit/ce28accff85c60422381a4084f026ab7d365d9b4) on a separate branch.

So it seemed warranted to try removing the performance issue with an as minimal change as possible while only changing the visual appearance for the better (i.e. it does the same except when the previous behavior was unintended, like the behavior near the bottom of the page).

The "trick":
* position `#toc` absolutely, to allow putting it next to the content
* give it 100% the height of its container
* also push it 100% to the right.
* 
* This should reliably put the element into the position the previous code was putting it.

## Performance improvement

The following screenshot compares performance during scrolling on the /spaces pages, [before](https://colorjs.io/docs/spaces) and [after ](https://deploy-preview-592--colorjs.netlify.app/docs/spaces) these changes. Both are on desktop, with no CPU throttling, so the improvement on lower end devices will be much greater.

* Time spent on style recalculation: 90% -> 0% (remaining purple is other rendering tasks)
* About 1 major GC / 200ms scrolling -> no major GC due to scrolling
* 25fps and main thread fully occupied -> 144fps and >50% idle time left

![colorjs-before-after](https://github.com/user-attachments/assets/176c75a4-fdcc-487a-acc1-117d68c7ac36)