### PR TITLE
Avoid full style recalculation by setting custom property only on element that uses it

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -9,10 +9,13 @@ if (location.pathname.indexOf("/docs/") > -1 && window.toc) {
 	import("./docs.js");
 }
 
-let root = document.documentElement;
-
 styleCallouts();
+let toc = document.getElementById("toc");
 
-document.addEventListener("scroll", evt => {
-	root.style.setProperty("--scrolltop", root.scrollTop);
-}, {passive: true});
+if (toc) {
+	let root = document.documentElement;
+
+	document.addEventListener("scroll", () => {
+		toc.style.setProperty("--scrolltop", root.scrollTop);
+	}, {passive: true});
+}


### PR DESCRIPTION
Addresses https://github.com/color-js/color.js/issues/587

This PR is a safer alternative to https://github.com/color-js/color.js/pull/592 as it does not change any of the CSS logic, it only sets the custom property at a lower level in the tree.

Since the `--scrolltop` custom property is only used on the `#toc` element, we can set its value on that element instead of the root element. This avoids a *full* style recalculation of all elements on the page which takes very long, and causes massive framerate drops during scrolling.

This should not result in any changed behavior or appearance as no other element uses the custom property. It should be a pure optimization with no risk for regressions.

Comparing the performance recordings before and after this change, you can observe the time spent on style recalculation is reduced to a fraction. The long purple chunks shrunk became almost too small to see on the right.

![colorjs-before-after-toc-optim](https://github.com/user-attachments/assets/bfb648db-58ea-4088-8d69-474eb38cd5a4)

https://colorjs.io/docs/spaces vs https://deploy-preview-597--colorjs.netlify.app/docs/spaces