### PR TITLE
Fix return type for deltas function

### DIFF
--- a/src/deltas.js
+++ b/src/deltas.js
@@ -39,7 +39,7 @@ export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 
 	let alpha = subtractCoords(c1.alpha, c2.alpha);
 
-	return { space: /** @type {ColorSpace} */ (c1.space), spaceId: ColorSpace.get(c1.space).id, coords, alpha };
+	return { space: /** @type {ColorSpace} */ (space), coords, alpha };
 }
 
 function subtractCoords (c1, c2) {

--- a/src/deltas.js
+++ b/src/deltas.js
@@ -6,6 +6,7 @@ import { isNone } from "./util.js";
 
 // Type "imports"
 /** @typedef {import("./types.js").ColorTypes} ColorTypes */
+/** @typedef {import("./types.js").DeltasReturn} DeltasReturn */
 
 /**
  * Get color differences per-component, on any color space
@@ -14,6 +15,7 @@ import { isNone } from "./util.js";
  * @param {object} options
  * @param {string | ColorSpace} [options.space=c1.space] - The color space to use for the delta calculation. Defaults to the color space of the first color.
  * @param {Parameters<typeof adjust>[0]} [options.hue="shorter"] - How to handle hue differences. Same as hue interpolation option.
+ * @returns {DeltasReturn}
  */
 export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 	c1 = getColor(c1);
@@ -37,7 +39,7 @@ export default function deltas (c1, c2, {space, hue = "shorter"} = {}) {
 
 	let alpha = subtractCoords(c1.alpha, c2.alpha);
 
-	return { space: c1.space, spaceId: ColorSpace.get(c1.space).id, coords, alpha };
+	return { space: /** @type {ColorSpace} */ (c1.space), spaceId: ColorSpace.get(c1.space).id, coords, alpha };
 }
 
 function subtractCoords (c1, c2) {

--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -72,3 +72,5 @@ export *                                from "./spaces/index-fn.js";
 /** @typedef {import("./types.js").CoordMeta} CoordMeta */
 /** @typedef {import("./types.js").Ref} Ref */
 /** @typedef {import("./types.js").SpaceOptions} SpaceOptions */
+// Re-exported from src/deltas.d.ts
+/** @typedef {import("./types.js").DeltasReturn} DeltasReturn */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -202,7 +202,6 @@ export type OKCoeff = [
 
 export interface DeltasReturn {
 	space: ColorSpace;
-	spaceId: string;
 	coords: [number, number, number];
 	alpha: number;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -199,3 +199,10 @@ export type OKCoeff = [
 		[number, number, number, number, number], // `Kn` coefficients
 	],
 ];
+
+export interface DeltasReturn {
+	space: ColorSpace;
+	spaceId: string;
+	coords: [number, number, number];
+	alpha: number;
+}

--- a/test/deltas.js
+++ b/test/deltas.js
@@ -1,6 +1,8 @@
 import "../src/spaces/index.js";
 import deltas from "../src/deltas.js";
 import * as check from "../node_modules/htest.dev/src/check.js";
+import { sRGB, OKLCH } from "../src/index-fn.js";
+
 
 export default {
 	name: "deltas() tests",
@@ -16,11 +18,11 @@ export default {
 				{
 					name: "Same color",
 					args: ["red", "red"],
-					expect: { spaceId: "srgb", coords: [0, 0, 0], alpha: 0 },
+					expect: { space: sRGB, coords: [0, 0, 0], alpha: 0 },
 				},
 				{
 					args: ["white", "black"],
-					expect: { spaceId: "srgb", coords: [1, 1, 1], alpha: 0 },
+					expect: { space: sRGB, coords: [1, 1, 1], alpha: 0 },
 				},
 				{
 					name: "Hues should never have a difference > 180 by default",
@@ -28,7 +30,7 @@ export default {
 						{spaceId: "oklch", coords: [.5, .2, -180]},
 						{spaceId: "oklch", coords: [.5, .2, 720]},
 					],
-					expect: { spaceId: "oklch", coords: [0, 0, 180], alpha: 0 },
+					expect: { space: OKLCH, coords: [0, 0, 180], alpha: 0 },
 				},
 				{
 					name: "If both coords are none, the delta should be none.",
@@ -36,7 +38,7 @@ export default {
 						{spaceId: "oklch", coords: [null, null, null], alpha: null},
 						{spaceId: "oklch", coords: [null, null, null], alpha: null},
 					],
-					expect: { spaceId: "oklch", coords: [null, null, null], alpha: null },
+					expect: { space: OKLCH, coords: [null, null, null], alpha: null },
 				},
 				{
 					name: "If one coord is none, the delta should be 0.",
@@ -44,7 +46,7 @@ export default {
 						{spaceId: "oklch", coords: [.5, .2, -180], alpha: null},
 						{spaceId: "oklch", coords: [null, null, null], alpha: .5},
 					],
-					expect: { spaceId: "oklch", coords: [0, 0, 0], alpha: 0 },
+					expect: { space: OKLCH, coords: [0, 0, 0], alpha: 0 },
 				},
 			],
 		},
@@ -54,11 +56,11 @@ export default {
 				{
 					name: "Same color",
 					args: ["red", "hsl(0 100% 50%)"],
-					expect: { spaceId: "srgb", coords: [0, 0, 0], alpha: 0 },
+					expect: { space: sRGB, coords: [0, 0, 0], alpha: 0 },
 				},
 				{
 					args: ["white", "hsl(0 100% 0%)"],
-					expect: { spaceId: "srgb", coords: [1, 1, 1], alpha: 0 },
+					expect: { space: sRGB, coords: [1, 1, 1], alpha: 0 },
 				},
 			],
 		},
@@ -68,11 +70,11 @@ export default {
 				{
 					name: "Same color",
 					args: ["red", "hsl(0 100% 50%)", { space: "oklch" }],
-					expect: { spaceId: "oklch", coords: [0, 0, 0], alpha: 0 },
+					expect: { space: OKLCH, coords: [0, 0, 0], alpha: 0 },
 				},
 				{
 					args: [{space: "srgb", coords: [1, 0, 0]}, {space: "srgb", coords: [.5, 0, 0]}, { space: "oklch" }],
-					expect: { spaceId: "oklch", coords: [0.2523245655926571, 0.10354211689049864, 0], alpha: 0 },
+					expect: { space: OKLCH, coords: [0.2523245655926571, 0.10354211689049864, 0], alpha: 0 },
 				},
 			],
 		},


### PR DESCRIPTION
The inferred type generated by Typescript for the result of the deltas function was incorrect. The `space` property had a type of `string | ColorSpace` when it should have been `ColorSpace`.

A new type called `DeltasReturn` has been added to fix the issue.

@LeaVerou not sure why we're returning the `space` and the `spaceId`. Can `spaceId` be removed?