### PR TITLE
[build] Build color-fn with ESM exports

### DIFF
--- a/_build/rollup.config.js
+++ b/_build/rollup.config.js
@@ -27,6 +27,11 @@ const fnBundles = [
 		"sourcemap": true,
 		"exports": "named",
 	},
+	{
+		"file": "dist/color-fn.js",
+		"format": "esm",
+		"sourcemap": true,
+	},
 ];
 
 // Add minified versions of every bundle

--- a/releases/v0.6.0.md
+++ b/releases/v0.6.0.md
@@ -102,6 +102,7 @@ There is also a new app:
 - New `colorSpace.isUnbounded` property by @lloydk in https://github.com/color-js/color.js/pull/503
 - Improved number parsing (by @facelessuser in #508)
 - `parse()` now clamps alpha as well, just like the `Color` constructor (by @LeaVerou)
+- Functional API now also available with ESM exports (#606)
 
 ### Performance
 

--- a/releases/v0.6.0.md
+++ b/releases/v0.6.0.md
@@ -102,7 +102,7 @@ There is also a new app:
 - New `colorSpace.isUnbounded` property by @lloydk in https://github.com/color-js/color.js/pull/503
 - Improved number parsing (by @facelessuser in #508)
 - `parse()` now clamps alpha as well, just like the `Color` constructor (by @LeaVerou)
-- Functional API now also available with ESM exports (#606)
+- Functional API now also available with ESM exports (by @MysteryBlokHed in #606)
 
 ### Performance
 


### PR DESCRIPTION
Closes #589

Also builds the color-fn API with ESM exports, which was previously missing.