### PR TITLE
Add Open Collective sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: color


### PR DESCRIPTION
Adding this file places a sponsor link in the sidebar to make it easier for people to find the Open Collective (see <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository>).

I think that there’s an option in the repository settings that needs to be enabled in order to actually display the sponsor link if/when this is merged (under General > Features > Sponsorships).

It might also make sense to create a new repository `color-js/.github` and add the file there, so that the button can be enabled for all repos in the organization.