### PR TITLE
Fix parsing 7 character hex colors successfully

### DIFF
--- a/src/spaces/srgb.js
+++ b/src/spaces/srgb.js
@@ -66,7 +66,7 @@ export default new RGBColorSpace({
 		"hex": {
 			type: "custom",
 			toGamut: true,
-			test: str => /^#([a-f0-9]{3,4}){1,2}$/i.test(str),
+			test: str => /^#(([a-f0-9]{2}){3,4}|[a-f0-9]{3,4})$/i.test(str),
 			parse (str) {
 				if (str.length <= 5) {
 					// #rgb or #rgba, duplicate digits

--- a/test/parse.js
+++ b/test/parse.js
@@ -92,6 +92,26 @@ const tests = {
 					expect: {spaceId: "srgb", coords: [1, 0, 0.4], alpha: 0.5333333333333333},
 				},
 				{
+					name: "Wrong number of characters (2) in hexadecimal notation",
+					args: "#12",
+					throws: TypeError,
+				},
+				{
+					name: "Wrong number of characters (5) in hexadecimal notation",
+					args: "#12345",
+					throws: TypeError,
+				},
+				{
+					name: "Wrong number of characters (7) in hexadecimal notation",
+					args: "#1234567",
+					throws: TypeError,
+				},
+				{
+					name: "Wrong number of characters (9) in hexadecimal notation",
+					args: "#123456789",
+					throws: TypeError,
+				},
+				{
 					name: "rgba(% % % / a)",
 					args: "rgba(0% 50% 200% / 0.5)",
 					expect: {spaceId: "srgb", coords: [0, 0.5, 2], alpha: 0.5},


### PR DESCRIPTION
## Changes

Fix parsing color strings in hexadecimal notation with 7 character successfully. This is caused by the sRGB color space's hex test regexp allowing a match of 3 valid characters followed by a match of 4 valid characters (and vice-versa). The fix is done by separating the regexp for the collapsed and non-collapsed forms.

Add four tests for invalid hex color strings with invalid lengths. Three of them (those for 2, 5, and 9 characters) pass without this fix. Only the one for 7 characters doesn't already.

## Notes

- I can't get the tests to run in my Windows environment using Terminal+PowerShell. I'm getting a `Error importing tests from C:\Users\phil\dev\color.js\test\adapt.js: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'` error for all test files. In my Ubuntu environment, they work however. It looks like there might be a dynamic import somewhere that is fed with a `c:\...`-style path but I couldn't find it in this repository or htest.