### PR TITLE
2 fixes for type="custom" ColorSpaces

### DIFF
--- a/src/Format.js
+++ b/src/Format.js
@@ -131,7 +131,12 @@ export default class Format {
 		return this.type === "function" || /** @type {any} */ (this).serialize;
 	}
 
-
+	/**
+	 * @returns Color
+	 */
+	parse () {
+		return null;
+	}
 	/**
 	 * @param {Format | FormatInterface} format
 	 * @param {RemoveFirstElement<ConstructorParameters<typeof Format>>} args

--- a/src/parse.js
+++ b/src/parse.js
@@ -123,7 +123,7 @@ export default function parse (str, options) {
 				// Convert to Format object
 				format = space.getFormat(format);
 
-				let color = format.parse?.(env.str);
+				let color = format.parse(env.str);
 
 				if (color) {
 					if (meta) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -131,7 +131,7 @@ export default function parse (str, options) {
 					}
 
 					ret = color;
-					break loop;
+					break spaceloop;
 				}
 			}
 		}

--- a/src/parse.js
+++ b/src/parse.js
@@ -108,7 +108,7 @@ export default function parse (str, options) {
 	}
 	else {
 		// Custom, colorspace-specific format
-		for (let space of ColorSpace.all) {
+		loop: for (let space of ColorSpace.all) {
 			for (let formatId in space.formats) {
 				let format = space.formats[formatId];
 
@@ -123,7 +123,7 @@ export default function parse (str, options) {
 				// Convert to Format object
 				format = space.getFormat(format);
 
-				let color = format.parse(env.str);
+				let color = format.parse?.(env.str);
 
 				if (color) {
 					if (meta) {
@@ -131,7 +131,7 @@ export default function parse (str, options) {
 					}
 
 					ret = color;
-					break;
+					break loop;
 				}
 			}
 		}

--- a/src/parse.js
+++ b/src/parse.js
@@ -108,7 +108,7 @@ export default function parse (str, options) {
 	}
 	else {
 		// Custom, colorspace-specific format
-		loop: for (let space of ColorSpace.all) {
+		spaceloop: for (let space of ColorSpace.all) {
 			for (let formatId in space.formats) {
 				let format = space.formats[formatId];
 


### PR DESCRIPTION
Two fixes that come out of this discussion: https://github.com/color-js/color.js/discussions/593

1) The code finds a match for a custom parse() function, but only exited the inner of two loops. Here it exits early via `break loop;` This was not only causing unnecessary iterations of the loop, it was causing issues with user ColorSpaces with `{type:"custom"}`.
2) The addition of `?.` in this line: 
```js
let color = format.parse?.(env.str);
```
so that "custom" ColorSpace formats don't require a `parse` property. The discussion linked above creates a custom ColorSpace with a default format that has a custom serialize() property/function, but doesn't need a parse property. The current code requires it to have a dummy parse() property/function that returns falsy. This change removes that requirement and prevents the throwing of unnecessary errors.

It is worth noting that there is only one built-in space with custom formats: sRGB, and it's the near the end of `ColorSpace.all`.  Is there a need to iterate over any other color spaces?