### PR TITLE
Fix jzczhz check for achromatic colors

### DIFF
--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -78,6 +78,7 @@ export interface SpaceOptions {
 	formats?: Record<string, Format> | undefined;
 	gamutSpace?: "self" | string | ColorSpace | null | undefined;
 	aliases?: string[] | undefined;
+	ε?: number | undefined;
 }
 
 export type Ref =
@@ -137,6 +138,7 @@ export default class ColorSpace {
 	referred?: string | undefined;
 	white: White;
 	gamutSpace: ColorSpace;
+	ε?: number | undefined;
 
 	from (color: ColorTypes): Coords;
 	from (space: string | ColorSpace, coords: Coords): Coords;

--- a/src/ColorSpace.js
+++ b/src/ColorSpace.js
@@ -85,6 +85,7 @@ export default class ColorSpace {
 
 		// Other stuff
 		this.referred = options.referred;
+		this.ε = options.ε;
 
 		// Compute ancestors and store them, since they will never change
 		Object.defineProperty(this, "path", {

--- a/src/spaces/jzczhz.js
+++ b/src/spaces/jzczhz.js
@@ -24,4 +24,5 @@ export default new ColorSpace({
 	base: Jzazbz,
 	fromBase: lch.fromBase,
 	toBase: lch.toBase,
+	ε: 0.0002363,
 });


### PR DESCRIPTION
The default `ε` (0.00001) calculated for `jzczhz` is to low for achromatic colors. The highest `az` or `bz` value for an achromatic color is `-0.00023625807422922307` for [color(rec2100-pq 1 1 1)](https://apps.colorjs.io/convert/?color=color(rec2100-pq%201%201%201)&precision=4).

The `ColorSpace` class has been modified to allow setting `ε` when constructing a `ColorSpace` and the `ε` for `jzczhz` has been set to `0.0002363`.

This new `ε` ensures that all achromatic colors up to the brightest white in `req2100-pq` have a null hue when converted to `jzczhz`.

However, with the new `ε` there are some non-achromatic colors near black in `rec2100-pq` that will be considered to be achromatic when converted to `jzczhz`. I think this is ok but I wanted to point them out.
```
// The non zero values in this list are either 1 / 255, 2 / 255 or 3 / 255.
color(rec2100-pq 0 0 0.00392156862745098)
color(rec2100-pq 0 0 0.00784313725490196)
color(rec2100-pq 0 0.00392156862745098 0)
color(rec2100-pq 0 0.00392156862745098 0.00392156862745098)
color(rec2100-pq 0 0.00392156862745098 0.00784313725490196)
color(rec2100-pq 0 0.00784313725490196 0)
color(rec2100-pq 0 0.00784313725490196 0.00392156862745098)
color(rec2100-pq 0 0.00784313725490196 0.00784313725490196)
color(rec2100-pq 0.00392156862745098 0 0)
color(rec2100-pq 0.00392156862745098 0 0.00392156862745098)
color(rec2100-pq 0.00392156862745098 0 0.00784313725490196)
color(rec2100-pq 0.00392156862745098 0.00392156862745098 0)
color(rec2100-pq 0.00392156862745098 0.00392156862745098 0.00784313725490196)
color(rec2100-pq 0.00392156862745098 0.00784313725490196 0)
color(rec2100-pq 0.00392156862745098 0.00784313725490196 0.00392156862745098)
color(rec2100-pq 0.00392156862745098 0.00784313725490196 0.00784313725490196)
color(rec2100-pq 0.00784313725490196 0 0)
color(rec2100-pq 0.00784313725490196 0 0.00392156862745098)
color(rec2100-pq 0.00784313725490196 0 0.00784313725490196)
color(rec2100-pq 0.00784313725490196 0.00392156862745098 0)
color(rec2100-pq 0.00784313725490196 0.00392156862745098 0.00392156862745098)
color(rec2100-pq 0.00784313725490196 0.00392156862745098 0.00784313725490196)
color(rec2100-pq 0.00784313725490196 0.00784313725490196 0)
color(rec2100-pq 0.00784313725490196 0.00784313725490196 0.00392156862745098)
color(rec2100-pq 0.00784313725490196 0.00784313725490196 0.011764705882352941)
color(rec2100-pq 0.00784313725490196 0.011764705882352941 0.00784313725490196)
color(rec2100-pq 0.00784313725490196 0.011764705882352941 0.011764705882352941)
color(rec2100-pq 0.011764705882352941 0.00784313725490196 0.00392156862745098)
color(rec2100-pq 0.011764705882352941 0.00784313725490196 0.00784313725490196)
color(rec2100-pq 0.011764705882352941 0.00784313725490196 0.011764705882352941)
color(rec2100-pq 0.011764705882352941 0.011764705882352941 0.00784313725490196)
```

I rounded the `ε`, I can change it to the exact number if that's a more appropriate value.
