### PR TITLE
Fix jzazbz

### DIFF
--- a/src/spaces/xyz-abs-d65.js
+++ b/src/spaces/xyz-abs-d65.js
@@ -31,10 +31,10 @@ export default new ColorSpace({
 		// Make XYZ absolute, not relative to media white
 		// Maximum luminance in PQ is 10,000 cd/m²
 		// Relative XYZ has Y=1 for media white
-		return XYZ.map(v => Math.max(v * Yw, 0));
+		return XYZ.map(v => v * Yw);
 	},
 	toBase (AbsXYZ) {
 		// Convert to media-white relative XYZ
-		return AbsXYZ.map(v => Math.max(v / Yw, 0));
+		return AbsXYZ.map(v =>v / Yw);
 	},
 });


### PR DESCRIPTION
Fixes some faults in `Jzazbz` but not fully, see

 - https://github.com/color-js/color.js/issues/613
 - https://github.com/color-js/color.js/issues/634

However these changes (don't clamp absolute XYZ to positive values, guard against negative powers in `Jzazbz` intermediate calculations) do help in terms of consistency with other implementations.