### PR TITLE
Fix types and type errors

### DIFF
--- a/scripts/generate-space-accessor-types.js
+++ b/scripts/generate-space-accessor-types.js
@@ -20,14 +20,14 @@ for (const spaceModule in spaces) {
 let template = `// DO NOT EDIT. This file is generated with \`npm run build:space-accessors\`.
 
 /** Proxy used for space accessors */
-export type SpaceAccessor = Record<string, number> & number[];
+export type SpaceAccessor = Record<string, number | null> & (number | null)[];
 
 declare class SpaceAccessors {`;
 for (const spaceId of Array.from(spaceIds).sort()) {
 	template += `\n\t${spaceId}: SpaceAccessor;`;
 }
 for (const coord of Array.from(coords).sort()) {
-	template += `\n\t${coord}: number;`;
+	template += `\n\t${coord}: number | null;`;
 }
 template += `
 }

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -27,7 +27,7 @@ export interface Format {
 	alpha?: boolean | undefined;
 	test?: ((str: string) => boolean) | undefined;
 	/** Function to parse a string into a color */
-	parse?: ((str: string) => ColorConstructor) | undefined;
+	parse?: ((str: string) => ColorConstructor | undefined | null) | undefined;
 	/**
 	 * Serialize coordinates and an alpha channel into a string.
 	 * Must be defined for a format to support serialization
@@ -116,6 +116,8 @@ export default class ColorSpace {
 
 	static get all (): ColorSpace[];
 
+	static findFormat (filters: object | string, spaces?: ColorSpace[]): FormatClass | null;
+
 	/** The ID used by CSS, such as `display-p3` or `--cam16-jmh` */
 	get cssId (): string;
 	get isPolar (): boolean;
@@ -146,4 +148,6 @@ export default class ColorSpace {
 	to (space: string | ColorSpace, coords: Coords): Coords;
 
 	toString (): string;
+
+	equals (space: string | ColorSpace): boolean;
 }

--- a/src/Format.js
+++ b/src/Format.js
@@ -31,6 +31,10 @@ export default class Format {
 	spaceCoords;
 	/** @type {Type[][]} */
 	coords;
+	/** @type {string | undefined} */
+	id;
+	/** @type {boolean | undefined} */
+	alpha;
 
 	/**
 	 * @param {FormatInterface} format
@@ -137,9 +141,10 @@ export default class Format {
 	}
 
 	/**
-	 * @returns Color
+	 * @param {string} str
+	 * @returns {(import("./types.js").ColorConstructor) | undefined | null}
 	 */
-	parse () {
+	parse (str) {
 		return null;
 	}
 

--- a/src/color.d.ts
+++ b/src/color.d.ts
@@ -54,19 +54,19 @@ export interface ColorObject {
 	spaceId?: string | ColorSpace | undefined;
 	space?: string | ColorSpace | undefined;
 	coords: Coords;
-	alpha?: number | undefined;
+	alpha?: number | undefined | null;
 }
 
 export interface PlainColorObject {
 	space: ColorSpace;
 	coords: Coords;
-	alpha: number;
+	alpha: number | null;
 }
 
 export interface ColorConstructor {
 	spaceId: string;
 	coords: Coords;
-	alpha: number | undefined;
+	alpha: number | undefined | null;
 }
 
 export type ColorTypes = ColorObject | ColorConstructor | string | PlainColorObject;
@@ -150,11 +150,11 @@ declare namespace Color {
  */
 declare class Color extends SpaceAccessors implements PlainColorObject {
 	constructor (color: ColorTypes);
-	constructor (space: string | ColorSpace, coords: Coords, alpha?: number);
+	constructor (space: string | ColorSpace, coords: Coords, alpha?: number | null);
 
 	// These signatures should always be the same as the constructor
 	static get (color: ColorTypes): Color;
-	static get (space: string | ColorSpace, coords: Coords, alpha: number): Color;
+	static get (space: string | ColorSpace, coords: Coords, alpha: number | null): Color;
 
 	static defineFunction (name: string, code: DefineFunctionHybrid): void;
 	static defineFunction (

--- a/src/parse.js
+++ b/src/parse.js
@@ -134,13 +134,13 @@ export default function parse (str, options) {
 				}
 
 				// Convert to Format object
-				format = space.getFormat(format);
+				let formatObject = space.getFormat(format);
 
-				let color = format.parse(env.str);
+				let color = formatObject.parse(env.str);
 
 				if (color) {
 					if (meta) {
-						Object.assign(meta, { format, formatId });
+						Object.assign(meta, { format: formatObject, formatId });
 					}
 
 					ret = color;

--- a/src/space-coord-accessors.d.ts
+++ b/src/space-coord-accessors.d.ts
@@ -1,7 +1,7 @@
 // DO NOT EDIT. This file is generated with `npm run build:space-accessors`.
 
 /** Proxy used for space accessors */
-export type SpaceAccessor = Record<string, number> & number[];
+export type SpaceAccessor = Record<string, number | null> & (number | null)[];
 
 declare class SpaceAccessors {
 	a98rgb: SpaceAccessor;
@@ -44,31 +44,31 @@ declare class SpaceAccessors {
 	xyz_abs_d65: SpaceAccessor;
 	xyz_d50: SpaceAccessor;
 	xyz_d65: SpaceAccessor;
-	a: number;
-	az: number;
-	b: number;
-	bz: number;
-	c: number;
-	cp: number;
-	ct: number;
-	cz: number;
-	g: number;
-	h: number;
-	hz: number;
-	i: number;
-	j: number;
-	jz: number;
-	l: number;
-	m: number;
-	r: number;
-	s: number;
-	t: number;
-	u: number;
-	v: number;
-	w: number;
-	x: number;
-	y: number;
-	z: number;
+	a: number | null;
+	az: number | null;
+	b: number | null;
+	bz: number | null;
+	c: number | null;
+	cp: number | null;
+	ct: number | null;
+	cz: number | null;
+	g: number | null;
+	h: number | null;
+	hz: number | null;
+	i: number | null;
+	j: number | null;
+	jz: number | null;
+	l: number | null;
+	m: number | null;
+	r: number | null;
+	s: number | null;
+	t: number | null;
+	u: number | null;
+	v: number | null;
+	w: number | null;
+	x: number | null;
+	y: number | null;
+	z: number | null;
 }
 
 export default SpaceAccessors;

--- a/src/spaces/cam16.js
+++ b/src/spaces/cam16.js
@@ -175,12 +175,16 @@ export function environment (
 	const d = discounting
 		? 1
 		: Math.max(Math.min(f * (1 - (1 / 3.6) * Math.exp((-env.la - 42) / 92)), 1), 0);
-	env.dRgb = rgbW.map(c => {
-		return interpolate(1, yw / c, d);
-	});
-	env.dRgbInv = env.dRgb.map(c => {
-		return 1 / c;
-	});
+	env.dRgb = /** @type {[number, number, number]} */ (
+		rgbW.map(c => {
+			return interpolate(1, yw / c, d);
+		})
+	);
+	env.dRgbInv = /** @type {[number, number, number]} */ (
+		env.dRgb.map(c => {
+			return 1 / c;
+		})
+	);
 
 	// Achromatic response
 	const rgbCW = /** @type {[number, number, number]} */ (

--- a/src/spaces/lch.js
+++ b/src/spaces/lch.js
@@ -26,6 +26,7 @@ export default new ColorSpace({
 	fromBase (Lab) {
 		// These methods are used for other polar forms as well, so we can't hardcode the ε
 		if (this.ε === undefined) {
+			// @ts-expect-error Property 'coords' does not exist on type 'string | ColorSpace'
 			let range = Object.values(this.base.coords)[1].refRange;
 			let extent = range[1] - range[0];
 			this.ε = extent / 100000;

--- a/src/spaces/srgb.js
+++ b/src/spaces/srgb.js
@@ -77,6 +77,7 @@ export default new RGBColorSpace({
 
 				/** @type {number[]} */
 				let rgba = [];
+				// @ts-expect-error Type 'void' is not assignable to type 'string'
 				str.replace(/[a-f0-9]{2}/gi, component => {
 					rgba.push(parseInt(component, 16) / 255);
 				});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -94,9 +94,21 @@ export interface ArgumentMeta {
 	none: boolean;
 }
 
+import FormatClass from "./Format.js";
+
+/** Metadata stored on Color objects */
+export interface ParseMeta {
+	format?: FormatClass | undefined;
+	formatId?: string;
+	name?: string;
+	types?: (string | undefined)[];
+	commas?: boolean;
+	alphaType?: "<number>" | "<percentage>" | undefined;
+}
+
 export interface ParseOptions {
 	/** Object to hold information about the parsing (format, types, etc.) */
-	meta?: ArgumentMeta | undefined;
+	meta?: ParseMeta | undefined;
 	/** Alias for {@link meta} */
 	parseMeta?: ParseOptions["meta"];
 }
@@ -134,7 +146,7 @@ export interface SerializeOptions {
 	 */
 	inGamut?: boolean | undefined;
 	/** Coordinate format to override the default */
-	coords?: Coords | undefined;
+	coords?: (string | undefined)[];
 	/** Alpha format */
 	alpha?:
 		| "<number>"

--- a/types/test/ColorSpace.ts
+++ b/types/test/ColorSpace.ts
@@ -41,6 +41,10 @@ ColorSpace.get(space);
 ColorSpace.get("abc", "def");
 ColorSpace.get(space, space);
 
+ColorSpace.findFormat("abc");
+ColorSpace.findFormat("abc", [space]);
+ColorSpace.findFormat({}, [space]);
+
 ColorSpace.register(space);
 ColorSpace.register("abc", space);
 
@@ -62,3 +66,5 @@ space.from({ space: space, coords: [1, 2, 3], alpha: 1 }); // $ExpectType Coords
 space.from({ space: space, coords: [1, 2, 3] }); // $ExpectType Coords
 space.from(space, [1, 2, 3]); // $ExpectType Coords
 space.from("srgb", [1, 2, 3]); // $ExpectType Coords
+
+space.equals(space); // $ExpectType boolean

--- a/types/test/color.ts
+++ b/types/test/color.ts
@@ -1,4 +1,5 @@
 import Color, { Coords } from "colorjs.io/src/color";
+import sRGB from "colorjs.io/src/spaces/srgb";
 
 // @ts-expect-error
 new Color();
@@ -7,6 +8,12 @@ new Color("red");
 new Color(new Color("red"));
 new Color("srgb", [1, 2, 3]);
 new Color("srgb", [1, 2, 3], 1);
+
+new Color({ space: sRGB , coords: [1, 1, 1], alpha: null });
+new Color({ spaceId: "srgb", coords: [1, 2, 3], alpha: null });
+new Color("srgb", [1, 2, 3], null);
+
+Color.get("srgb", [1, 2, 3], null);
 
 const color = new Color("red");
 color.alpha; // $ExpectType number

--- a/types/test/space-accessors.ts
+++ b/types/test/space-accessors.ts
@@ -10,3 +10,7 @@ color.srgb[2] = 1;
 color.srgb.r = 1;
 color.srgb.g = 1;
 color.srgb.b = 1;
+
+color.srgb[0] = null;
+color.srgb.r = null;
+color.r = null;


### PR DESCRIPTION
- changed Color* types to allow null for alpha
- added `findFormat` and equals functions to the `ColorSpace` type
- added types for the `id` and `alpha` properties of the `Format` class to fix type errors in the `parse` function
- minor code changes to eliminate type errors in the `parse` function.
- added a `ParseMeta` interface to `types.d.ts` for the metadata stored on Color objects
- fixed type errors in the `serialize` function related to `parseMeta`.
- Other miscellaneous fixes to correct types and type errors.

