### PR TITLE
fix: hsl parsing not being spec-compliant

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -99,7 +99,7 @@ export default function parse (str, options) {
 
 		let alpha = 1;
 
-		if (format.alpha === true || env.parsed.lastAlpha) {
+		if (env.parsed.lastAlpha) {
 			alpha = env.parsed.args.pop();
 
 			if (meta) {
@@ -245,11 +245,17 @@ export function parseFunction (str) {
 		let args = [];
 		let argMeta = [];
 		let lastAlpha = false;
+		let name = parts[1].toLowerCase();
 
 		let separators = parts[2].replace(regex.singleArgument, ($0, rawArg) => {
 			let { value, meta } = parseArgument(rawArg);
 
-			if ($0.startsWith("/")) {
+			if (
+				// If there's a slash here, it's modern syntax
+				$0.startsWith("/")
+				// If there's still elements to process after there's already 3 in `args` (and the we're not dealing with "color()"), it's likely to be a legacy color like "hsl(0, 0%, 0%, 0.5)"
+				|| (name !== "color" && args.length === 3)
+			) {
 				// It's alpha
 				lastAlpha = true;
 			}
@@ -260,7 +266,7 @@ export function parseFunction (str) {
 		});
 
 		return {
-			name: parts[1].toLowerCase(),
+			name,
 			args,
 			argMeta,
 			lastAlpha,

--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -85,10 +85,10 @@ export default new ColorSpace({
 
 	formats: {
 		hsl: {
-			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"],
 		},
 		hsla: {
-			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
+			coords: ["<number> | <angle>", "<percentage> | <number>", "<percentage> | <number>"],
 			commas: true,
 			alpha: true,
 		},

--- a/test/parse.js
+++ b/test/parse.js
@@ -565,6 +565,60 @@ const tests = {
 					args: "hsl(230.6 179.7% 37.56% / 1)",
 					expect: { spaceId: "hsl", coords: [230.6, 179.7, 37.56], alpha: 1 },
 				},
+				{
+					name: "legacy syntax, <percentage> saturation/lightness, no alpha (#428, #648)",
+					args: ["hsl(0, 0%, 0%)"],
+					expect: { spaceId: "hsl", coords: [0, 0, 0], alpha: 1 },
+				},
+				{
+					name: "legacy syntax, <percentage> saturation/lightness, alpha (#428, #648)",
+					args: ["hsl(0, 0%, 0%, 0.5)"],
+					expect: { spaceId: "hsl", coords: [0, 0, 0], alpha: 0.5 },
+				},
+				{
+					name: "legacy syntax, <number> saturation/lightness, no alpha (#428, #648)",
+					args: ["hsl(0, 0, 0)"],
+					throws: true,
+					// TODO: #428. This currently parses successfully but shouldn't because the legacy syntax doesn't allow `<number>` for saturation or lightness.
+					skip: true,
+				},
+				{
+					name: "legacy syntax, <number> saturation/lightness, alpha (#428, #648)",
+					args: ["hsl(0, 0, 0, 0.5)"],
+					throws: true,
+					// TODO: #428. This currently parses successfully but shouldn't because the legacy syntax doesn't allow `<number>` for saturation or lightness.
+					skip: true,
+				},
+				{
+					name: "modern syntax, <percentage> saturation/lightness, no alpha (#428, #648)",
+					args: ["hsl(0 50% 25%)"],
+					expect: { spaceId: "hsl", coords: [0, 50, 25], alpha: 1 },
+				},
+				{
+					name: "modern syntax, <percentage> saturation/lightness, alpha (#428, #648)",
+					args: ["hsl(0 50% 25% / 50%)"],
+					expect: { spaceId: "hsl", coords: [0, 50, 25], alpha: 0.5 },
+				},
+				{
+					name: "modern syntax, <number> saturation/lightness, no alpha (#428, #648)",
+					args: ["hsl(0 50 25)"],
+					expect: { spaceId: "hsl", coords: [0, 50, 25], alpha: 1 },
+				},
+				{
+					name: "modern syntax, <number> saturation/lightness, alpha (#428, #648)",
+					args: ["hsl(0 50 25 / 50%)"],
+					expect: { spaceId: "hsl", coords: [0, 50, 25], alpha: 0.5 },
+				},
+				{
+					name: "modern syntax, unit-ful <angle> hue, no alpha (#428, #648)",
+					args: ["hsla(240deg 100% 50%)"],
+					expect: { spaceId: "hsl", coords: [240, 100, 50], alpha: 1 },
+				},
+				{
+					name: "modern syntax, unit-ful <angle> hue, alpha (#428, #648)",
+					args: ["hsla(240deg 100% 50% / 0.5)"],
+					expect: { spaceId: "hsl", coords: [240, 100, 50], alpha: 0.5 },
+				},
 			],
 		},
 		{


### PR DESCRIPTION
## Changes

Add the `<number>` type to the saturation and lightness coordinates (i.e. changing them from `<percentage>` to `<percentage> | <number>`) for the HSL color space to match the specification (see https://www.w3.org/TR/css-color-4/#funcdef-hsl).

Make parsing independent from the `format.alpha` configuration of color spaces and instead rely on the parser to identify whether there is a "last alpha" element in a color string using functional notation. This way, colors that are being parsed with a format that sets `format.alpha` to `true` (for serialization purposes) can still omit the alpha value which is valid in both legacy and modern syntax for hsl/hsla colors.

Closes #428, #648.

## Notes

- **Important**: Currently (both before and with this PR's changes), HSL colors in the legacy functional format parse fine with `<number>` values for saturation/lightness. Two skipped tests are added for this.
- This pull request contains a significant change to the parsing logic that needs careful review. Specifically, there's one assumption I'm making about the structure of color strings in functional notation: I assume that all color strings in functional notation **except `color()`** that have four "elements" contain the alpha channel in the last element. Now I know this is certainly not true for relative CSS colors (e.g. `lch(from blue calc(l + 20) c h)`), but I'm not sure there's ever a chance for the current parsing logic to handle such colors. In other words, I assume that the parsing logic I changed deals exclusively with `<color-function>` excluding specifically `color()`.
- The exclusion of `color()` is possibly something that can be addressed, but I wanted to keep the scope of this PR clear. From a quick look at https://www.w3.org/TR/css-color-4/#predefined, a similar assumption as above could be made for `color()`: Perhaps one can assume that all `color()` strings that have five "elements" contain the alpha channel in the last element.
- I used the currently failing examples from the issues #428 and #648 in the tests, feel free to suggest more cases that are useful to test.
- Only related on a meta level: I found working with the test suite a little tricky because logging expressions was difficult. For one, logging synchronously would often lead to nothing being logged. I eventually resorted to using the following timeout-based technique which isn't ideal:

  ```js
  let messages = [JSON.stringify({ lastAlpha: env.parsed.lastAlpha, args: env.parsed.args })]
  global.setTimeout(() => console.log(messages.join(':')), 15)
  ```

  Furthermore, I found myself commenting out a lot of the tests to reduce the noise while logging. htest now has support for `skip` which is useful, but while working on code, I regularly use `only` flags for _only_ running tests within a test suite flagged as such without the need to disable them otherwise. 