### PR TITLE
fix: parser not being able to distinguish between legacy and modern formats

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -251,16 +251,18 @@ export function parseFunction (str) {
 		/** @type {ArgumentMeta[]} */
 		let argMeta = [];
 		let lastAlpha = false;
-		let name = parts[1].toLowerCase();
+		let rawName = parts[1];
+		let rawArgs = parts[2];
+		let name = rawName.toLowerCase();
 
-		let separators = parts[2].replace(regex.singleArgument, ($0, rawArg) => {
+		let separators = rawArgs.replace(regex.singleArgument, ($0, rawArg) => {
 			let { value, meta } = parseArgument(rawArg);
 
 			if (
 				// If there's a slash here, it's modern syntax
 				$0.startsWith("/") ||
-				// If there's still elements to process after there's already 3 in `args` (and the we're not dealing with "color()"), it's likely to be a legacy color like "hsl(0, 0%, 0%, 0.5)"
-				(name !== "color" && args.length === 3)
+				// If there's still elements to process after there's already 3 in `args` (and there are commas), it's a legacy syntax like "hsl(0, 0%, 0%, 0.5)"
+				(args.length === 3 && rawArgs.includes(","))
 			) {
 				// It's alpha
 				lastAlpha = true;
@@ -277,8 +279,8 @@ export function parseFunction (str) {
 			argMeta,
 			lastAlpha,
 			commas: separators.includes(","),
-			rawName: parts[1],
-			rawArgs: parts[2],
+			rawName,
+			rawArgs,
 		};
 	}
 }

--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -93,5 +93,14 @@ export default new ColorSpace({
 			commas: true,
 			alpha: true,
 		},
-	}
+		hsl_legacy: {
+			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
+			commas: true,
+		},
+		hsla_legacy: {
+			coords: ["<number> | <angle>", "<percentage>", "<percentage>"],
+			commas: true,
+			alpha: true,
+		},
+	},
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -116,7 +116,7 @@ export interface ParseOptions {
 
 export interface ParseFunctionReturn {
 	name: string;
-	args: string[];
+	args: (string | number)[];
 	argMeta: ArgumentMeta[];
 	lastAlpha: boolean;
 	rawName: string;

--- a/test/parse.js
+++ b/test/parse.js
@@ -586,16 +586,12 @@ const tests = {
 				{
 					name: "legacy syntax, <number> saturation/lightness, no alpha (#428, #648)",
 					args: ["hsl(0, 0, 0)"],
-					throws: true,
-					// TODO: #428. This currently parses successfully but shouldn't because the legacy syntax doesn't allow `<number>` for saturation or lightness.
-					skip: true,
+					throws: TypeError,
 				},
 				{
 					name: "legacy syntax, <number> saturation/lightness, alpha (#428, #648)",
 					args: ["hsl(0, 0, 0, 0.5)"],
-					throws: true,
-					// TODO: #428. This currently parses successfully but shouldn't because the legacy syntax doesn't allow `<number>` for saturation or lightness.
-					skip: true,
+					throws: TypeError,
 				},
 				{
 					name: "modern syntax, <percentage> saturation/lightness, no alpha (#428, #648)",


### PR DESCRIPTION
For code review, commit 3 `fix: parser not being able to distinguish between legacy and modern formats` is the core of what the PR title suggests. Commits 1 and 2 are related to the code this work touches, but themselves not essential for the commit 3. As such, I'd be completely fine with a request to drop them or split them off into a separate PR.

## Changes

**refactor: correct parseArgument types**

Avoid the `/** @type {ArgumentMeta} */ (meta)` type assertion and use `/** @satisfies {ArgumentMeta} */ (meta)` instead to ensure `meta` conforms to the `ArgumentMeta` type.

**chore: add comma check to legacy syntax parsing check to be more robust**

Make the parser check identifying whether a parameter is the alpha channel more robust by checking for the presence of commas in the color string when checking for legacy syntaxes. This also allows for the removal of the `name !== "color"` check as modern color syntaxes can't contain commas.

**fix: parser not being able to distinguish between legacy and modern formats**

Validate the parsed CSS types for elements in color strings that are using functional syntax against the coordinate grammar defined in the corresponding color space. If a disallowed type is found in the parsed color, a `TypeError` is thrown.

To actually distinguish legacy and modern syntaxes, the parser was updated to look for a named format with a `_legacy` suffix first (e.g. parsing an `hsl` color will look for `hsl_legacy` first and then for `hsl`). This is not a good system as it's not flexible and because it relies on somewhat strangely named formats to be defined in the library. Ideally, color spaces define their grammar kind of like the specification does. The parser would identify the color space and then check if the parsed color matches any of the space's grammar(s) (e.g. for HSL one of legacy hsl/hsla or modern hsl/hsla). I also think it would be useful to distinguish between grammars (parsing) and formats (serialization). However, any further structural changes to the parsing logic would blow up the scope of this change which intends to fix the incorrect parsing of legacy HSL colors.

Closes #648.

## Notes

As stated in the commit messages, I'm not happy with the approach of the `_legacy`-suffixed formats. I'd prefer a comprehensive grammar definition separately from formats to be used to try and match a parsed color string.

The grammars for the HSL color space could be defined like this (based on https://www.w3.org/TR/css-color-4/#funcdef-hsl):

```js
const hsl = {
  grammars: [
    {
      name: "hsl",
      label: "<modern-hsl-syntax>",
      parameters: [
        {
          types: ["<hue>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
          optional: true,
        },
      ],
    },
    {
      name: "hsla",
      label: "<modern-hsla-syntax>",
      parameters: [
        {
          types: ["<hue>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
        },
        {
          types: ["<percentage>", "<number>", "none"],
          optional: true,
        },
      ],
    },
    {
      name: "hsl",
      label: "<legacy-hsl-syntax>",
      legacy: true,
      parameters: [
        {
          types: ["<hue>"],
        },
        {
          types: ["<percentage>"],
        },
        {
          types: ["<percentage>"],
        },
        {
          types: ["<percentage>", "<number>"],
          optional: true,
        },
      ],
    },
    {
      name: "hsla",
      label: "<legacy-hsla-syntax>",
      legacy: true,
      parameters: [
        {
          types: ["<hue>"],
        },
        {
          types: ["<percentage>"],
        },
        {
          types: ["<percentage>"],
        },
        {
          types: ["<percentage>", "<number>"],
          optional: true,
        },
      ],
    },
  ],
}
```

I haven't worked on anything using it so I can't say how ergonomic this is, but it should have all the information needed to accurately parse _all_ specified color variants. The optional `legacy` property (`false` by default) on a grammar definition would be used to indicate the necessity of commas in the parameter list. The `optional` property (`false` by default) on a parameter definition would be used to mark a parameter as optional. Lastly, `types` lists the allowed CSS types per parameter. This schema also allows for such specifics like legacy RGB colors only allowing `<percentage>` _or_ `<number>` and not a mix of them.

Since introducing anything like this would affect all color space definitions, this would be well out of scope for what I set out to fix in this change which is to fix the parsing of legacy HSL colors.