### PR TITLE
Fix return types of the darken/lighten functions on the Color class

### DIFF
--- a/src/color.d.ts
+++ b/src/color.d.ts
@@ -284,8 +284,8 @@ declare class Color extends SpaceAccessors implements PlainColorObject {
 	// variations
 	lighten: ToColorPrototype<typeof lighten>;
 	darken: ToColorPrototype<typeof darken>;
-	static lighten: typeof lighten;
-	static darken: typeof darken;
+	static lighten: ToColorNamespace<typeof lighten>;
+	static darken: ToColorNamespace<typeof darken>;
 }
 
 export default Color;

--- a/src/variations.js
+++ b/src/variations.js
@@ -27,3 +27,9 @@ export function darken (color, amount = 0.25) {
 	let /** @type {Ref} */ lightness = [space, "l"];
 	return set(color, lightness, l => l * (1 - amount));
 }
+
+/** @type {"color"} */
+lighten.returns = "color";
+
+/** @type {"color"} */
+darken.returns = "color";

--- a/types/test/variations.ts
+++ b/types/test/variations.ts
@@ -14,3 +14,13 @@ darken();
 darken("red"); // $ExpectType PlainColorObject
 darken(new Color("red")); // $ExpectType PlainColorObject
 darken("red", 25); // $ExpectType PlainColorObject
+
+new Color("red").lighten(); // $ExpectType Color
+new Color("red").lighten(0.5); // $ExpectType Color
+new Color("red").darken(); // $ExpectType Color
+new Color("red").darken(0.5); // $ExpectType Color
+
+Color.lighten("red"); // $ExpectType Color
+Color.lighten("red", 0.5); // $ExpectType Color
+Color.darken("red"); // $ExpectType Color
+Color.darken("red", 0.5); // $ExpectType Color


### PR DESCRIPTION
Changes the types of the `lighten` and `darken` instance and static functions to return `Color` instead of `PlainColorObject`.

Also fixes an issue with the static functions returning a `PlainColorObject` instead of a `Color` when anything but a `Color` object was passed to them. For example:

`new Color("red").lighten()` would return a `PlainColorObject` instead of a `Color` object.

Fixes #652
