### PR TITLE
Improve procedural API for all color spaces use case, rel #661

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
 				"default": "./dist/color-fn.cjs"
 			}
 		},
-		"./dist/*": "./dist/*"
+		"./spaces": "./src/spaces/index.js",
+		"./dist/*": "./dist/*",
+		"./src/*": "./src/*"
 	},
 	"typesVersions": {
 		"*": {

--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -33,6 +33,10 @@ export *                                  from "./deltaE/index.js";
 export { default as deltaEMethods }       from "./deltaE/index.js";
 export *                                  from "./variations.js";
 export { mix, steps, range, isRange }     from "./interpolation.js";
+
+// Export all color spaces as a single object as well so they can be registered in one go (#661)
+import * as spaces from "./spaces/index-fn.js";
+export { spaces }
 export *                                  from "./spaces/index-fn.js";
 
 // Type re-exports


### PR DESCRIPTION
- Single export for all color spaces in `/fn` so they can be registered in one go
- `/spaces` export that exports all color spaces and automatically registers them
- `/src` export as a catch-all because we are bound to have missed more things

Doesn't close #661, but addresses the most pressing pain point.