### PR TITLE
[types] Add types for `spaces` and `src` exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,19 @@
 				"default": "./dist/color-fn.cjs"
 			}
 		},
-		"./spaces": "./src/spaces/index.js",
-		"./dist/*": "./dist/*",
-		"./src/*": "./src/*"
+		"./spaces": {
+			"import": {
+				"types": "./types/src/spaces/index.d.ts",
+				"default": "./src/spaces/index.js"
+			}
+		},
+		"./src/*": {
+			"import": {
+				"types": "./types/src/*",
+				"default": "./src/*"
+			}
+		},
+		"./dist/*": "./dist/*"
 	},
 	"typesVersions": {
 		"*": {


### PR DESCRIPTION
Closes #666

This commit doesn't touch the exports for `dist`, it just fixes the types for `spaces` and `src`. I only specified the `import` property for each of the two exports, since the files use ESM exports and wouldn't work with `require`.

Example (from #666):

```typescript
import { toPrecision } from "colorjs.io/src/util.js";
```

Is now typed properly.