### PR TITLE
[spaces/rec2020] Use gamma 2.40 for display-referred rec2020 #669

### DIFF
--- a/data/modules.json
+++ b/data/modules.json
@@ -77,6 +77,13 @@
 			"description": "A very wide gamut RGB color space used in 4k and 8k UHDTV. It is currently difficult to make a screen which displays the entire REC.2020 gamut; current movies broadcast in this colorspace do not use the full gamut, although they do use a little more than P3."
 		},
 		{
+			"name": "REC.2020 Scene Referred",
+			"id": "--rec2020-oetf",
+			"dependencies": ["srgb"],
+			"url": "https://en.wikipedia.org/wiki/Rec._2020",
+			"description": "Scene-referred version of REC.2020"
+		},
+		{
 			"name": "REC.2100-PQ",
 			"id": "rec2100pq",
 			"dependencies": ["rec2020"],

--- a/src/spaces/index-fn.js
+++ b/src/spaces/index-fn.js
@@ -21,6 +21,7 @@ export { default as ProPhoto_Linear } from "./prophoto-linear.js";
 export { default as ProPhoto } from "./prophoto.js";
 export { default as REC_2020_Linear } from "./rec2020-linear.js";
 export { default as REC_2020 } from "./rec2020.js";
+export { default as REC_2020_Scene_Referred } from "./rec2020-oetf.js";
 export { default as OKLab } from "./oklab.js";
 export { default as OKLCH } from "./oklch.js";
 export { default as OKLrab } from "./oklrab.js";

--- a/src/spaces/rec2020-oetf.js
+++ b/src/spaces/rec2020-oetf.js
@@ -2,25 +2,37 @@ import RGBColorSpace from "../RGBColorSpace.js";
 import REC2020Linear from "./rec2020-linear.js";
 // import sRGB from "./srgb.js";
 
+const α = 1.09929682680944;
+const β = 0.018053968510807;
+
 export default new RGBColorSpace({
-	id: "rec2020",
-	name: "REC.2020",
+	id: "--rec2020-oetf",
+	name: "REC.2020_Scene_Referred",
 	base: REC2020Linear,
-	//  Reference electro-optical transfer function from Rec. ITU-R BT.1886 Annex 1
-	//  with b (black lift) = 0 and a (user gain) = 1
-	//  defined over the extended range, not clamped
+	referred: "scene",
+	// Non-linear transfer function from Rec. ITU-R BT.2020-2 table 4
 	toBase (RGB) {
 		return RGB.map(function (val) {
 			let sign = val < 0 ? -1 : 1;
 			let abs = val * sign;
-			return sign * Math.pow(abs, 2.40);
+
+			if (abs < β * 4.5) {
+				return val / 4.5;
+			}
+
+			return sign * Math.pow((abs + α - 1) / α, 1 / 0.45);
 		});
 	},
 	fromBase (RGB) {
 		return RGB.map(function (val) {
 			let sign = val < 0 ? -1 : 1;
 			let abs = val * sign;
-			return sign * Math.pow(abs, 1/2.40);
+
+			if (abs >= β) {
+				return sign * (α * Math.pow(abs, 0.45) - (α - 1));
+			}
+
+			return 4.5 * val;
 		});
 	},
 });


### PR DESCRIPTION
rename previous implementation as scene-referred --rec2020-oetf so people can still use the older implementation if they want

See

 - https://github.com/w3c/csswg-drafts/issues/12574#issuecomment-3156578544