### PR TITLE
[ci] Make download count workflow run weekly

### DIFF
--- a/.github/workflows/download_count.yaml
+++ b/.github/workflows/download_count.yaml
@@ -3,7 +3,7 @@ name: Update Download Count
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1"
 
 jobs:
   update-downloads:


### PR DESCRIPTION
Mentioned briefly in <https://github.com/color-js/color.js/pull/610#issuecomment-3368391155>

To reduce the noise in the commit log caused by the workflow. This change makes the workflow run [every Monday at midnight](https://crontab.guru/#0_0_*_*_1).