### PR TITLE
[ci] Use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   node-version: "lts/*"
 
-            - run: npm install
+            - run: npm ci
             - run: npm run lint:ci
             - name: Detect changes
               id: changes
@@ -28,5 +28,6 @@ jobs:
             - name: Fail if there are uncommitted changes
               if: steps.changes.outputs.count > 0
               run: |
+                git diff
                 echo "::error title=Uncommitted changes::run \"npm run lint\" to fix"
                 exit 1


### PR DESCRIPTION
Prevents npm from touching the lockfile when running in CI, which fixes the CI error we've been having.

Also adds a call to `git diff` in case of errors so that it's easier to spot the reason for CI failures in the future.

See: https://docs.npmjs.com/cli/v11/commands/npm-ci