### PR TITLE
First stab at fixing the primary nav on small viewports

### DIFF
--- a/_includes/partials/_nav-links.njk
+++ b/_includes/partials/_nav-links.njk
@@ -1,16 +1,34 @@
-<a href="{{ page | relative }}/get/">Get<span class="wide"> Color.js</span></a>
-<div class="menu">
+<a href="{{ page | relative }}/get/" data-nav-item="1">Get<span class="wide"> Color.js</span></a>
+<div class="menu" data-nav-item="2">
 	<a href="{{ page | relative }}/docs/">Docs</a>
 	<ul>
 		{% include "./_docs-nav.njk" %}
 	</ul>
 </div>
-<a href="{{ page | relative }}/api/">API</a>
-<a href="{{ page | relative }}/notebook/">Play!</a>
-<a href="https://apps.colorjs.io/">Demos</a>
-<a href="https://elements.colorjs.io/">Elements</a>
-<a href="{{ page | relative }}/test/" class="footer">Tests</a>
-<a href="https://github.com/LeaVerou/color.js">GitHub</a>
-<a href="https://discord.gg/K64FJBznq4">Discord</a>
-<a href="https://opencollective.com/color">♡&nbsp;Sponsor</a>
-<a href="https://github.com/LeaVerou/color.js/issues/new" class="footer">File bug</a>
+<a href="{{ page | relative }}/api/" data-nav-item="3">API</a>
+<a href="{{ page | relative }}/notebook/" data-nav-item="4">Play!</a>
+<a href="https://apps.colorjs.io/" data-nav-item="5">Demos</a>
+<a href="https://elements.colorjs.io/" data-nav-item="6">Elements</a>
+<a href="{{ page | relative }}/test/" class="footer" data-nav-item="7">Tests</a>
+<a href="https://github.com/LeaVerou/color.js" data-nav-item="8">GitHub</a>
+<a href="https://discord.gg/K64FJBznq4" data-nav-item="9">Discord</a>
+<a href="https://opencollective.com/color" data-nav-item="10">♡&nbsp;Sponsor</a>
+<a href="https://github.com/LeaVerou/color.js/issues/new" class="footer" data-nav-item="11">File bug</a>
+<div class="hamburger-menu">
+	<button class="hamburger-button" aria-label="Menu">
+		<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 48 48">
+			<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M7.95 11.95h32m-32 12h32m-32 12h32"/>
+		</svg>
+	</button>
+	<ul class="hamburger-list">
+		<li data-nav-item="1" hidden><a href="{{ page | relative }}/get/">Get Color.js</a></li>
+		<li data-nav-item="2" hidden><a href="{{ page | relative }}/docs/">Docs</a></li>
+		<li data-nav-item="3" hidden><a href="{{ page | relative }}/api/">API</a></li>
+		<li data-nav-item="4" hidden><a href="{{ page | relative }}/notebook/">Play!</a></li>
+		<li data-nav-item="5" hidden><a href="https://apps.colorjs.io/">Demos</a></li>
+		<li data-nav-item="6" hidden><a href="https://elements.colorjs.io/">Elements</a></li>
+		<li data-nav-item="8" hidden><a href="https://github.com/LeaVerou/color.js">GitHub</a></li>
+		<li data-nav-item="9" hidden><a href="https://discord.gg/K64FJBznq4">Discord</a></li>
+		<li data-nav-item="10" hidden><a href="https://opencollective.com/color">♡&nbsp;Sponsor</a></li>
+	</ul>
+</div>

--- a/_includes/plain.njk
+++ b/_includes/plain.njk
@@ -13,6 +13,7 @@
 <link rel="stylesheet" href="{{ page | relative }}/assets/css/style.css">
 
 <script src="{{ page | relative }}/color.js" type="module"></script>
+<script src="{{ page | relative }}/assets/js/nav.js" type="module"></script>
 
 {% if has_mavo %}
 <link rel="stylesheet" href="https://get.mavo.io/mavo.css">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,7 +197,7 @@ body > footer {
 	animation: var(--rainbow-scroll);
 
 	& nav {
-		& > .menu {
+		& > :where(.menu, .hamburger-menu) {
 			flex: 1;
 			display: flex;
 			position: relative;
@@ -224,13 +224,14 @@ body > footer {
 			}
 		}
 
-		& a {
+		& a:where(:not([hidden])) {
 			display: block;
 			text-align: center;
 		}
 
 		& > .menu > a,
-		& a:not(.logo) {
+		& a:not(.logo),
+	 	& .hamburger-button {
 			flex: 1;
 			padding: .6em;
 			font-weight: 800;
@@ -241,6 +242,33 @@ body > footer {
 				-webkit-background-clip: initial;
 				color: white;
 				text-decoration: none;
+			}
+		}
+
+		.hamburger-menu {
+			&:has(li:last-of-type[hidden]) {
+				/* All menu items are hidden; hide the menu */
+				display: none;
+			}
+
+			& .hamburger-button {
+				display: grid;
+				place-items: center;
+				border: none;
+				cursor: default;
+				text-align: center;
+				color: hsl(var(--gray) 40%);
+
+				> svg {
+					width: 100%;
+				}
+			}
+
+			& .hamburger-list {
+				min-inline-size: 15ch;
+				right: 0;
+				top: 100%;
+				transform-origin: top right;
 			}
 		}
 	}
@@ -295,6 +323,7 @@ body > header {
 
 			& img {
 				height: 2.15em;
+				min-width: 1.3em;
 				margin-bottom: -1.5em;
 				margin-left: -.3em;
 			}
@@ -426,7 +455,7 @@ pre[class*="language-"] {
 }
 
 @supports (-webkit-background-clip: text) and (not (-moz-margin-start: 0)) {
-	body > header nav a,
+	body > header nav :where(a, .hamburger-button),
 	body > footer nav a,
 	main h2,
 	main h2 > a {

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,0 +1,77 @@
+/**
+ * Responsive Navigation Script
+ * Dynamically hides navigation items that don't fit on screen in the main nav
+ * and shows them in the hamburger menu instead. Uses ResizeObserver to monitor
+ * the nav element and checks items from right to left to determine which ones
+ * overflow. Items are matched between nav and hamburger menu using data-nav-item
+ * attributes.
+ */
+
+const nav = document.querySelector("header nav");
+const menu = nav.querySelector(".hamburger-menu");
+const [menuButton, menuList] = menu.children;
+
+// Map to track nav items and their hamburger menu counterparts
+let itemMap = new Map();
+
+// Get all nav items (excluding the hamburger menu and the ones that are supposed to be shown in the footer)
+let navItems = [...nav.children].filter(
+	child => !child.classList.contains("hamburger-menu") && !child.classList.contains("footer"),
+);
+
+let hamburgerMenuItems = [...menuList.children];
+for (let navItem of navItems) {
+	let index = navItem.dataset.navItem;
+	let hamburgerItem = hamburgerMenuItems.find(item => item.dataset.navItem === index);
+	if (hamburgerItem) {
+		itemMap.set(navItem, hamburgerItem);
+	}
+}
+
+const resizeObserver = new ResizeObserver(checkFit);
+resizeObserver.observe(nav);
+
+function checkFit () {
+	// Reset: show all items in nav, hide all in hamburger
+	itemMap.forEach((hamburgerItem, navItem) => {
+		navItem.hidden = false;
+		hamburgerItem.hidden = true;
+	});
+
+	// Temporarily show hamburger menu to measure its width
+	menu.style.setProperty("display", "block");
+
+	let hamburgerButtonWidth = menuButton.offsetWidth ?? 50;
+	let navRect = nav.getBoundingClientRect();
+	let navRight = navRect.right;
+	let availableRight = navRight - hamburgerButtonWidth;
+
+	let items = [...itemMap.keys()];
+	let toHide = [];
+
+	// Check each item from right to left to see which ones overflow
+	// by comparing their right edge to available space
+	for (let i = items.length - 1; i >= 0; i--) {
+		const item = items[i];
+		const itemRect = item.getBoundingClientRect();
+		const itemRight = itemRect.right;
+		// If this item's right edge exceeds available space, hide it
+		if (itemRight > availableRight) {
+			toHide.push(item);
+		}
+		else {
+			// Once we find an item that fits, we can stop
+			break;
+		}
+	}
+
+	menu.style.removeProperty("display");
+
+	// Hide items in nav and show corresponding items in hamburger menu
+	for (let navItem of toHide) {
+		let hamburgerItem = itemMap.get(navItem);
+
+		navItem.hidden = true;
+		hamburgerItem.hidden = false;
+	}
+}


### PR DESCRIPTION
### Summary

- Introduce a responsive navigation system that “moves” overflowed items into a hamburger menu. These changes make the header adapt to smaller viewports and
prevent wrapping/overflow of nav items.
- Tweak the corresponding CSS rules and header image sizing (so it doesn’t shrink to 0 width and entirely disappear).

After some experiments, I’ve decided to duplicate menu items in two places (instead of programmatically moving them) to avoid DOM manipulations as much as possible. For me, it seems a reasonable trade-off since our nav menu is not huge, and RO might fire quite often.