### PR TITLE
An escape hatch to correctly render emojis inside clipped text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -436,6 +436,12 @@ pre[class*="language-"] {
 		-webkit-background-clip: text;
 		color: transparent;
 	}
+	
+	.emoji {
+		background: none;
+		-webkit-background-clip: initial;
+		color: initial;
+	}
 }
 
 .read-more::before {

--- a/releases/v0.6.0.md
+++ b/releases/v0.6.0.md
@@ -4,7 +4,7 @@ This has taken a while and three pre-releases, but we wanted to make sure we got
 This is likely to be the last v0.x release, as Color.js is certainly mature enough to go to v1 in the next major version.
 Speaking of maturity…
 
-## ⬇️ Over 100 million downloads! 🤯
+## <span class="emoji">⬇️</span> Over 100 million downloads! <span class="emoji">🤯</span>
 
 [Color.js has now been downloaded over 114 million times on npm!](https://limonte.dev/total-npm-downloads/?package=colorjs.io)
 The rate of increase is still accelerating, currently at **3.5 million downloads per week**!


### PR DESCRIPTION
I.e., inside blocks of text with the `-webkit-background-clip: text` CSS rule applied.

See https://deploy-preview-702--colorjs.netlify.app/releases/v0.6.0 as an example.