### PR TITLE
[types] Add `collapse` option to `SerializeOptions`

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -142,6 +142,11 @@ export interface SerializeOptions {
 	 */
 	format?: string | Format | undefined;
 	/**
+	 * Whether or not to collapse colors to three- or four-digit hex when possible
+	 * @default true
+	 */
+	collapse?: boolean | undefined;
+	/**
 	 * Adjust coordinates to fit in gamut first
 	 * @default false
 	 */

--- a/types/test/serialize.ts
+++ b/types/test/serialize.ts
@@ -10,3 +10,4 @@ serialize("red", {}); // $ExpectType string
 serialize("red", { precision: 5, format: "default", inGamut: false }); // $ExpectType string
 serialize("red", { precision: 5, format: "default", inGamut: false, foo: "bar" }); // $ExpectType string
 serialize("red", { format: { name: "CustomFormat", id: "custom-format" } }); // $ExpectType string
+serialize("red", { format: "hex", collapse: false }); // $ExpectType string


### PR DESCRIPTION
Fixes <https://github.com/color-js/color.js/issues/266#issuecomment-3773654144>

The sRGB space defines this option here:

<https://github.com/color-js/color.js/blob/ba0e0c49dee12e407bbaf3690b97d4ac790fb066/src/spaces/srgb.js#L90-L97>

Which can be called from `serialize` via:

<https://github.com/color-js/color.js/blob/ba0e0c49dee12e407bbaf3690b97d4ac790fb066/src/serialize.js#L80-L89>