### PR TITLE
Add `types` field back to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 			]
 		}
 	},
+	"types": "./types",
 	"type": "module",
 	"main": "./dist/color.cjs",
 	"module": "./dist/color.js",


### PR DESCRIPTION
Closes #707

Adds back the `types` field that was inadvertently left out of the changes in #564.