### PR TITLE
[website] Add extensible head block to layout

### DIFF
--- a/_includes/plain.njk
+++ b/_includes/plain.njk
@@ -12,7 +12,7 @@
 <link rel="shortcut icon" href="{{ page | relative }}/logo.svg">
 <link rel="stylesheet" href="{{ page | relative }}/assets/css/style.css">
 
-{% block head_extra %}{% endblock %}
+{% block head %}{% endblock %}
 
 <script src="{{ page | relative }}/color.js" type="module"></script>
 


### PR DESCRIPTION
Add a new ~`head_extra`~ `head` block to the plain layout template to allow child templates to inject additional content into the document head.

Rel. to https://github.com/color-js/elements/pull/223.