### PR TITLE
[spaces/helmgenlch] Add cssId for color() serialization

### DIFF
--- a/src/spaces/helmgenlch.js
+++ b/src/spaces/helmgenlch.js
@@ -14,6 +14,7 @@ import lch from "./lch.js";
 export default new ColorSpace({
 	id: "helmgenlch",
 	name: "HelmGenLCh",
+	cssId: "--helmgenlch",
 	coords: {
 		l: {
 			refRange: [0, 1],

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -144,6 +144,27 @@ const tests = {
 			],
 		},
 		{
+			name: "Custom color() spaces with dashed-ident",
+			tests: [
+				{
+					args: ["helmgen", [0.5, 0.1, -0.05]],
+					expect: "color(--helmgen 0.5 0.1 -0.05)",
+				},
+				{
+					args: ["helmgenlch", [0.5, 0.1, 30]],
+					expect: "color(--helmgenlch 0.5 0.1 30)",
+				},
+				{
+					args: ["helmlab-metric", [0.5, 0.1, -0.05]],
+					expect: "color(--helmlab-metric 0.5 0.1 -0.05)",
+				},
+				{
+					args: ["helmgenlch", [0.5, 0.1, 30], 0.8],
+					expect: "color(--helmgenlch 0.5 0.1 30 / 0.8)",
+				},
+			],
+		},
+		{
 			name: "Values outside of range or refRange",
 			tests: [
 				{


### PR DESCRIPTION
## Summary

Adds `cssId: "--helmgenlch"` to the HelmGenLCh color space registration. Without it, the serializer fell back to `space.id` (`"helmgenlch"`) and produced an invalid `color(helmgenlch …)` — CSS Color Module Level 4 requires a dashed-ident for custom `color()` spaces.

```js
// Before
new Color("helmgenlch", [0.5, 0.1, 30]).toString();
// → "color(helmgenlch 0.5 0.1 30)"   ❌ invalid CSS

// After
// → "color(--helmgenlch 0.5 0.1 30)"  ✅
```

The chosen identifier (`--helmgenlch`) mirrors the convention already used by the sibling spaces (`--helmgen`, `--helmlab-metric`).

## Test plan

- [x] `npm test` — all 770 tests pass (4 new, 0 regressions)
- [x] `npx eslint` clean on changed files
- [x] `npx prettier --check` clean

Added regression coverage in `test/serialize.js` for the dashed-ident output of `helmgen`, `helmgenlch`, and `helmlab-metric` (with and without alpha) so this can't silently regress again.

Fixes #730