### PR TITLE
Add AI-assisted contributions section (closes #723)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,20 @@ All of the above also have `build` versions (e.g. `npm run build:js` or `npm run
 - If working on a color space, please prefix your commit with `[spaces/SPACE_ID]`
 - If working on a module other than color.js, please prefix your commit with `[modulename]` e.g. `[interpolation]`
 
+## AI-assisted contributions
+
+We welcome contributions that use AI assistants (Claude, Copilot, Cursor, etc.) provided you treat them as **drafting tools, not authors**: review and test what they produce as if you wrote it yourself, and be transparent about it.
+
+If AI was involved in producing a contribution:
+
+- **Verify and test the code yourself.** You're responsible for what you submit. Pay particular attention to areas the test suite doesn't exercise — AI tools can produce code that *looks* correct but quietly violates an unstated constraint.
+- **Don't let AI assistants post on your behalf without explicit approval.** This applies to PR comments, issue replies, and any direct interaction with maintainers or other contributors. Read each message before it goes out — even if you asked the assistant to draft it.
+- **Mark commits with `Co-Authored-By:`.** Claude Code does this automatically; for other tools, add the trailer manually. Example: `Co-Authored-By: Claude <noreply@anthropic.com>`.
+- **Disclose AI use in PRs and issues** whose text was largely generated, e.g. with a note at the end:
+  > _Drafted with the help of Claude._
+
+Submitting AI-generated content as if it were your own — without review, testing, or attribution — wastes maintainer time and isn't welcome. See #723 for the discussion behind this policy.
+
 ## Code style
 
 Please install an ESLint plugin for your editor. There is an `.eslintrc.json` file in the repo which encodes most of the coding style of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All of the above also have `build` versions (e.g. `npm run build:js` or `npm run
 
 ## AI-assisted contributions
 
-We welcome contributions that use AI assistants (Claude, Copilot, Cursor, etc.) provided you treat them as **drafting tools, not authors**: review and test what they produce as if you wrote it yourself, and be transparent about it.
+We welcome contributions that use AI assistants provided you treat them as **drafting tools, not authors**: review and test what they produce as if you wrote it yourself, and be transparent about it.
 
 If AI was involved in producing a contribution:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We welcome contributions that use AI assistants (Claude, Copilot, Cursor, etc.) 
 
 If AI was involved in producing a contribution:
 
-- **Verify and test the code yourself.** You're responsible for what you submit. Pay particular attention to areas the test suite doesn't exercise — AI tools can produce code that *looks* correct but quietly violates an unstated constraint.
+- **Verify and test the code yourself.** You're responsible for what you submit. Pay particular attention to areas that cannot be validated via unit testing, such as architectural coherence.
 - **Don't let AI assistants post on your behalf without explicit approval.** This applies to PR comments, issue replies, and any direct interaction with maintainers or other contributors. Read each message before it goes out — even if you asked the assistant to draft it.
 - **Mark commits with `Co-Authored-By:`.** Claude Code does this automatically; for other tools, add the trailer manually. Example: `Co-Authored-By: Claude <noreply@anthropic.com>`.
 - **Disclose AI use in PRs and issues** whose text was largely generated, e.g. with a note at the end:


### PR DESCRIPTION
This codifies the policy discussed in #723 as a new section in `CONTRIBUTING.md`, placed between "Commit messages" and "Code style".

The section covers:
- Reviewing and testing AI-generated code (including the test-coverage caveat raised by @facelessuser)
- Not letting AI assistants post comments/replies on your behalf without explicit approval
- `Co-Authored-By:` trailer for commits
- Disclosure note at the end of largely-AI-generated PRs/issues

Happy to move the section, trim bullets, or rephrase. The broader questions (skill for AI *using* Color.js, AI contributor conventions) are tracked separately in #732 — this PR doesn't block on them.

---
_Drafted with the help of Claude._