### PR TITLE
Add HSL P3 and HSL Rec.2020 color spaces

### DIFF
--- a/src/spaces/hsl-p3.js
+++ b/src/spaces/hsl-p3.js
@@ -1,0 +1,28 @@
+import ColorSpace from "../ColorSpace.js";
+import P3 from "./p3.js";
+import HSL from "./hsl.js";
+
+export default new ColorSpace({
+	id: "hsl-p3",
+	name: "HSL P3",
+	coords: {
+		h: {
+			refRange: [0, 360],
+			type: "angle",
+			name: "Hue",
+		},
+		s: {
+			range: [0, 100],
+			name: "Saturation",
+		},
+		l: {
+			range: [0, 100],
+			name: "Lightness",
+		},
+	},
+
+	base: P3,
+	rgbGamut: P3,
+	fromBase: HSL.fromBase,
+	toBase: HSL.toBase,
+});

--- a/src/spaces/hsl-p3.js
+++ b/src/spaces/hsl-p3.js
@@ -4,6 +4,7 @@ import HSL from "./hsl.js";
 
 export default new ColorSpace({
 	id: "hsl-p3",
+	cssId: "--hsl-p3",
 	name: "HSL P3",
 	coords: {
 		h: {

--- a/src/spaces/hsl-rec2020.js
+++ b/src/spaces/hsl-rec2020.js
@@ -4,6 +4,7 @@ import HSL from "./hsl.js";
 
 export default new ColorSpace({
 	id: "hsl-rec2020",
+	cssId: "--hsl-rec2020",
 	name: "HSL Rec.2020",
 	coords: {
 		h: {

--- a/src/spaces/hsl-rec2020.js
+++ b/src/spaces/hsl-rec2020.js
@@ -1,0 +1,28 @@
+import ColorSpace from "../ColorSpace.js";
+import REC2020 from "./rec2020.js";
+import HSL from "./hsl.js";
+
+export default new ColorSpace({
+	id: "hsl-rec2020",
+	name: "HSL Rec.2020",
+	coords: {
+		h: {
+			refRange: [0, 360],
+			type: "angle",
+			name: "Hue",
+		},
+		s: {
+			range: [0, 100],
+			name: "Saturation",
+		},
+		l: {
+			range: [0, 100],
+			name: "Lightness",
+		},
+	},
+
+	base: REC2020,
+	rgbGamut: REC2020,
+	fromBase: HSL.fromBase,
+	toBase: HSL.toBase,
+});

--- a/src/spaces/index-fn.js
+++ b/src/spaces/index-fn.js
@@ -11,6 +11,8 @@ export { default as LCH } from "./lch.js";
 export { default as sRGB_Linear } from "./srgb-linear.js";
 export { default as sRGB } from "./srgb.js";
 export { default as HSL } from "./hsl.js";
+export { default as HSL_P3 } from "./hsl-p3.js";
+export { default as HSL_REC2020 } from "./hsl-rec2020.js";
 export { default as HWB } from "./hwb.js";
 export { default as HSV } from "./hsv.js";
 export { default as P3_Linear } from "./p3-linear.js";

--- a/test/conversions.js
+++ b/test/conversions.js
@@ -152,6 +152,54 @@ const tests = {
 			],
 		},
 		{
+			name: "P3 to HSL P3",
+			data: {
+				toSpace: "hsl-p3",
+			},
+			tests: [
+				{
+					args: "color(display-p3 1 0 0)",
+					expect: [0, 100, 50],
+				},
+				{
+					args: "color(display-p3 0.5 0.2 0.7)",
+					expect: [276, 55.55555555555556, 44.99999999999999],
+				},
+				{
+					args: "color(display-p3 1 1 1)",
+					expect: [null, 0, 100],
+				},
+				{
+					args: "color(display-p3 0 0 0)",
+					expect: [null, 0, 0],
+				},
+				{
+					args: ["color(--hsl-p3 276 55 45)", "p3"],
+					expect: [0.49949999999999983, 0.20249999999999999, 0.6975],
+				},
+			],
+		},
+		{
+			name: "Rec.2020 to HSL Rec.2020",
+			data: {
+				toSpace: "hsl-rec2020",
+			},
+			tests: [
+				{
+					args: "color(rec2020 0 0 1)",
+					expect: [240, 100, 50],
+				},
+				{
+					args: "color(rec2020 0.5 0.2 0.7)",
+					expect: [276, 55.55555555555556, 44.99999999999999],
+				},
+				{
+					args: ["color(--hsl-rec2020 240 80 30)", "rec2020"],
+					expect: [0.06, 0.06, 0.54],
+				},
+			],
+		},
+		{
 			name: "P3 to sRGB",
 			data: {
 				toSpace: "srgb",


### PR DESCRIPTION
Add `hsl-p3` and `hsl-rec2020` color spaces, applying the HSL algorithm to wide-gamut RGB bases.

Follows the LCH/OkLCh convention: reuse `HSL.fromBase`/`toBase` with the base and `rgbGamut` swapped to P3 / Rec.2020 respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)