### PR TITLE
Smarter `display()` fallback: base color space chain & `displaySpaces`

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -108,8 +108,12 @@ As of June 2022, `cssColor` will be sRGB in Chrome and Firefox, and P3 in Safari
 
 So, this works, but the process is a little tedious. Thankfully, Color.js has got your back!
 Simply use the `color.display()` method.
-By default, it will use the widest of the default set of fallbacks ([Lab](spaces.html#lab), [REC.2020](spaces.html#rec2020), [P3](spaces.html#p3), then [sRGB](spaces.html#srgb)),
-but you can also provide your own space when the color to be output is not supported by the current browser.
+When the color is not supported by the current browser, it stays as close as possible to the
+original: it converts to the first supported space in the color's own base color space chain
+(which preserves its gamut), or to a space's declared `displaySpaces` if it defines any.
+If none of those are supported, it uses the widest of the default set of fallbacks
+([Lab](spaces.html#lab), [REC.2020](spaces.html#rec2020), [P3](spaces.html#p3), then [sRGB](spaces.html#srgb)).
+You can also provide your own space to convert to instead, which always takes precedence.
 Note that in Node, the fallback space is always sRGB if not provided.
 Let's rewrite the example above using `color.display()`!
 

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -7,7 +7,7 @@ import { White } from "./adapt.js";
 import { ColorConstructor, Coords, ColorTypes } from "./color.js";
 import type FormatClass from "./Format.js";
 import type { instance } from "./Format.js";
-import RGBColorSpace from "./RGBColorSpace.js"
+import RGBColorSpace from "./RGBColorSpace.js";
 
 export interface Format {
 	/** @default "function" */
@@ -76,6 +76,10 @@ export interface SpaceOptions {
 	 */
 	formats?: Record<string, Format> | undefined;
 	gamutSpace?: "self" | string | ColorSpace | null | undefined;
+	/**
+	 * Spaces to try if not natively supported, if different from base chain.
+	 */
+	displaySpaces?: (string | ColorSpace)[] | undefined;
 	aliases?: string[] | undefined;
 	ε?: number | undefined;
 	rgbGamut?: RGBColorSpace | undefined;
@@ -133,6 +137,8 @@ export default class ColorSpace {
 	base: ColorSpace | null;
 	/** This space's ancestors, ordered closest first (immediate base → root), excluding this space */
 	bases: ColorSpace[];
+	/** Spaces to try when serializing for display and this space is not natively supported */
+	displaySpaces?: ColorSpace[] | undefined;
 	coords: Record<string, CoordMeta>;
 	fromBase?: ((coords: Coords) => Coords) | undefined;
 	toBase?: ((coords: Coords) => Coords) | undefined;

--- a/src/ColorSpace.d.ts
+++ b/src/ColorSpace.d.ts
@@ -131,6 +131,8 @@ export default class ColorSpace {
 	id: string;
 	aliases?: string[] | undefined;
 	base: ColorSpace | null;
+	/** This space's ancestors, ordered closest first (immediate base → root), excluding this space */
+	bases: ColorSpace[];
 	coords: Record<string, CoordMeta>;
 	fromBase?: ((coords: Coords) => Coords) | undefined;
 	toBase?: ((coords: Coords) => Coords) | undefined;

--- a/src/ColorSpace.js
+++ b/src/ColorSpace.js
@@ -20,6 +20,13 @@ export default class ColorSpace {
 		this.name = options.name;
 		this.base = options.base ? ColorSpace.get(options.base) : null;
 		this.aliases = options.aliases;
+		this.displaySpaces = options.displaySpaces?.map(space => ColorSpace.get(space));
+
+		// This space's ancestors, closest first (immediate base → root), excluding the space itself.
+		this.bases = [];
+		for (let base = this.base; base; base = base.base) {
+			this.bases.push(base);
+		}
 
 		if (options.rgbGamut) {
 			this.rgbGamut = options.rgbGamut;

--- a/src/display.js
+++ b/src/display.js
@@ -37,7 +37,10 @@ if (typeof CSS !== "undefined" && CSS.supports) {
 /**
  * Returns a serialization of the color that can actually be displayed in the browser.
  * If the default serialization can be displayed, it is returned.
- * Otherwise, the color is converted to Lab, REC2020, or P3, whichever is the widest supported.
+ * Otherwise, if a `space` is given, the color is converted directly to it.
+ * If not, the color is converted to the first supported of its space's `displaySpaces` (if any),
+ * else the closest supported space in its base color space chain (which preserves its gamut),
+ * else the default fallback space (Lab, REC2020, or P3, whichever is the widest supported).
  * In Node.js, this is basically equivalent to `serialize()` but returns a `String` object instead.
  * @param {ColorTypes} color
  * @param {DisplayOptions} [options] Options. Any properties beyond `space` and `supports` are passed to `serialize()`.
@@ -85,7 +88,33 @@ export default function display (
 			}
 		}
 
-		// If we're here, the color function is not supported
+		// If we're here, the color function is not supported.
+		// With no explicit space, try the color's own `displaySpaces`, or else walk up its base
+		// color space chain (closest first, skipping XYZ connection spaces), and use the first
+		// space the browser supports, before falling back to the default space.
+		if (space === undefined) {
+			space = fallbackColor.space;
+			let candidates = space.displaySpaces ?? space.bases;
+
+			// Skip XYZ connection spaces (unless the space itself is one, so it still has a fallback).
+			if (!space.displaySpaces && !space.id.startsWith("xyz-")) {
+				candidates = candidates.filter(space => !space.id.startsWith("xyz-"));
+			}
+
+			for (let candidate of candidates) {
+				let candidateColor = to(fallbackColor, candidate);
+				let str = serialize(candidateColor, options);
+
+				if (supports("color", /** @type {string} */ (str))) {
+					ret = /** @type {Display} */ (new String(str));
+					ret.color = candidateColor;
+					return ret;
+				}
+			}
+
+			space = defaults.display_space;
+		}
+
 		// Fall back to fallback space
 		fallbackColor = to(fallbackColor, /** @type {string | ColorSpace} */ (space));
 		ret = /** @type {Display} */ (new String(serialize(fallbackColor, options)));

--- a/src/display.js
+++ b/src/display.js
@@ -44,16 +44,15 @@ if (typeof CSS !== "undefined" && CSS.supports) {
  * @returns {Display} String object containing the serialized color
  * with a color property containing the converted color (or the original, if no conversion was necessary)
  */
-export default function display (color, { space, supports = globalThis.CSS?.supports, ...options } = {}) {
+export default function display (
+	color,
+	{ space, supports = globalThis.CSS?.supports, ...options } = {},
+) {
 	color = getColor(color);
 
 	let ret = /** @type {Display} */ (serialize(color, options));
 
-	if (
-		!supports ||
-		supports("color", /** @type {string} */ (ret)) ||
-		!defaults.display_space
-	) {
+	if (!supports || supports("color", /** @type {string} */ (ret)) || !defaults.display_space) {
 		ret = /** @type {Display} */ (new String(ret));
 		ret.color = /** @type {PlainColorObject} */ (color);
 	}


### PR DESCRIPTION
## What

Makes `color.display()` stay as close as possible to the original color when the browser doesn't natively support its serialization, instead of always jumping to the widest default fallback (`lab()`/etc.).

Resolution order when a color isn't supported:

1. An explicit `space` option — converted to directly (unchanged, still wins).
2. The color space's own `displaySpaces` (new opt-in override), if defined.
3. Otherwise, walk up the **base color space chain**, closest first, and use the first supported ancestor — this preserves the color's gamut (e.g. an `hsl-p3` color falls back to `color(display-p3 …)` rather than `lab()`). XYZ connection spaces are skipped.
4. If none of the above are supported, the existing default fallback space (widest of Lab/REC.2020/P3, then sRGB).

## API additions

- **`ColorSpace` `displaySpaces` option** — an ordered list of spaces to try for display when the space isn't natively supported, overriding the base-chain walk.

(Relies on `ColorSpace#bases`, already on `main`.)

## Notes

- Behavior in Node is unchanged: with no `supports()`/`CSS.supports` available, the color's own serialization is returned.
- Docs updated in `docs/output.md`.

## Test plan

- [x] `npx tsc` — 0 errors
- [x] Full test suite — 702 pass, 0 failures
- [x] Manually verified with a mocked `supports`: base-chain (`hsl-rec2020 → color(rec2020 …)`, `hsl-p3 → color(display-p3 …)`), explicit-space precedence, `displaySpaces` override, and Node default (native serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)