### PR TITLE
Remove ESM bundles and point to source directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ all with sensible defaults
 
 Color.js is designed make simple things easy, and complex things possible, and that extends to installation as well.
 
-For quick experiments, you can just import Color.js directly from the CDN (kindly provided by the awesome folks at [Netlify](https://netlify.com)) with all modules included:
+For quick experiments, you can just import Color.js directly from a CDN such as [esm.sh](https://esm.sh) with all modules included:
 
 ```js
-import Color from "https://colorjs.io/dist/color.js";
+import Color from "https://esm.sh/colorjs.io";
 ```
 
 You can also install via npm if you’d prefer:

--- a/_build/rollup.config.js
+++ b/_build/rollup.config.js
@@ -6,11 +6,6 @@ const bundles = [
 		name: "Color",
 	},
 	{
-		file: "dist/color.js",
-		format: "esm",
-		sourcemap: true,
-	},
-	{
 		file: "dist/color.cjs",
 		format: "cjs",
 		sourcemap: true,
@@ -24,11 +19,6 @@ const fnBundles = [
 		format: "cjs",
 		sourcemap: true,
 		exports: "named",
-	},
-	{
-		file: "dist/color-fn.js",
-		format: "esm",
-		sourcemap: true,
 	},
 ];
 

--- a/assets/js/colors.js
+++ b/assets/js/colors.js
@@ -1,4 +1,4 @@
-import Color from "../../dist/color.js";
+import Color from "../../src/index.js";
 
 let root = document.documentElement;
 let root_cs = getComputedStyle(root);

--- a/get/index.njk
+++ b/get/index.njk
@@ -10,7 +10,7 @@ includes: '<link rel="stylesheet" href="style.css"><script src="index.js" type="
 
 <p>If you just want to play around ASAP, the quickest way is to import the entire library, either as a module in your JS:</p>
 
-<pre><code>import Color from "https://colorjs.io/dist/color.js";</code></pre>
+<pre><code>import Color from "https://esm.sh/colorjs.io";</code></pre>
 
 <p class="warning">To be able to use <code>import</code> statements in your JS, your <code class="language-markup">&lt;script></code> element needs <code>type="module"</code></p>
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		".": {
 			"import": {
 				"types": "./types/index.d.ts",
-				"default": "./dist/color.js"
+				"default": "./src/index.js"
 			},
 			"require": {
 				"types": "./types/index.d.ts",
@@ -53,7 +53,7 @@
 	"types": "./types",
 	"type": "module",
 	"main": "./dist/color.cjs",
-	"module": "./dist/color.js",
+	"module": "./src/index.js",
 	"directories": {
 		"test": "tests"
 	},


### PR DESCRIPTION
Closes #662

This PR removes the pre-built ESM bundles from the distribution and updates all references to point directly to the source files instead.

## Summary
The ESM bundles (`dist/color.js` and `dist/color-fn.js`) are being removed since ESM consumers can import directly from the source via the package's `exports` field. This simplifies the build process and reduces maintenance overhead by eliminating the need to keep bundled ESM files in sync with source changes.

It also fixes the dual-instance problem behind [color-js/elements#192](https://github.com/color-js/elements/issues/192): when the main `.` export resolved to a separate bundled copy, consumers importing `src/` got a different `Color` (with its own color-space registry) than those importing the package root, so custom spaces registered through one didn't appear in the other.

## Key Changes
- **Package.json**: Updated the `.` ESM `exports` and the `module` field to point to `src/index.js` instead of the bundled `dist/color.js`, matching how `./fn` and `./spaces` already export `src/`.
- **Rollup config**: Removed ESM bundle configurations for both main and function-based builds, keeping only IIFE (global) and CommonJS formats.
- **Documentation & examples**: Updated import statements in the README, the get page, and the website's own `colors.js` asset to reference `src/index.js` directly.

## Implementation Details
- ESM consumers now import directly from source, which is already supported via the package's `exports` configuration.
- CommonJS users continue to use the bundled `dist/color.cjs` (and `dist/color-fn.cjs` for `./fn`).
- Classic `<script>` users continue to use the global IIFE build (`dist/color.global.js`), and the `.legacy` CommonJS/global builds are unaffected.
