### PR TITLE
[interpolation] Fix `steps` using `deltaEMethod` inconsistently

### DIFF
--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -78,7 +78,7 @@ export function steps (c1, c2, options = {}) {
 		colorRange = range(c1, c2, rangeOptions);
 	}
 
-	let totalDelta = deltaE(c1, c2);
+	let totalDelta = deltaE(c1, c2, deltaEMethod);
 	let actualSteps =
 		maxDeltaE > 0 ? Math.max(steps, Math.ceil(totalDelta / maxDeltaE) + 1) : steps;
 	let ret = [];
@@ -120,7 +120,11 @@ export function steps (c1, c2, options = {}) {
 
 				let p = (cur.p + prev.p) / 2;
 				let color = colorRange(p);
-				maxDelta = Math.max(maxDelta, deltaE(color, prev.color), deltaE(color, cur.color));
+				maxDelta = Math.max(
+					maxDelta,
+					deltaE(color, prev.color, deltaEMethod),
+					deltaE(color, cur.color, deltaEMethod),
+				);
 				ret.splice(i, 0, { p, color: colorRange(p) });
 				i++;
 			}


### PR DESCRIPTION
Fixes #632 

I stumbled over the same issue. Due to my limited experience with color stuff I'm not sure this fix is correct, especially since [this comment](https://github.com/color-js/color.js/issues/632#issuecomment-3689743575) mentions that some parts might already have been fixed, which I can't find - but this change fixes the error, the resulting colors look roughly as I'd expect them to, and the same amount of tests pass with and without.

Hope this is useful!