### PR TITLE
[ci] Fix install command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   node-version: "lts/*"
 
-            - run: npm ci
+            - run: npm install
             - run: npm run lint:ci
             - name: Detect changes
               id: changes


### PR DESCRIPTION
No longer works as-is due to the removal of the lockfile from the repository; `npm ci` expects a lockfile

Opened as a PR instead of committing directly so that the workflow could be tested first