### PR TITLE
Preserve a subclass's own toBase/fromBase when options omit them

### DIFF
--- a/src/ColorSpace.js
+++ b/src/ColorSpace.js
@@ -37,8 +37,14 @@ export default class ColorSpace {
 		}
 
 		if (this.base) {
-			this.fromBase = options.fromBase;
-			this.toBase = options.toBase;
+			// Keep a subclass's own methods if the options don't override them
+			if (options.fromBase) {
+				this.fromBase = options.fromBase;
+			}
+
+			if (options.toBase) {
+				this.toBase = options.toBase;
+			}
 		}
 
 		// Coordinate metadata


### PR DESCRIPTION
## What

In `ColorSpace`'s constructor, when a space has a `base`, `fromBase`/`toBase` were assigned from the options unconditionally:

```js
if (this.base) {
	this.fromBase = options.fromBase;
	this.toBase = options.toBase;
}
```

This clobbers any `toBase`/`fromBase` a **subclass** defines on its prototype with `undefined` whenever those functions aren't passed through the options. This change assigns them only when provided:

```js
if (this.base) {
	// Keep a subclass's own methods if the options don't override them
	if (options.fromBase) {
		this.fromBase = options.fromBase;
	}

	if (options.toBase) {
		this.toBase = options.toBase;
	}
}
```

## Why

This is a small, self-contained improvement that lets `ColorSpace` subclasses implement `toBase`/`fromBase` as methods. It was factored out of a larger work-in-progress branch since it stands on its own and is useful independently. Existing spaces pass `fromBase`/`toBase` via options, so behavior for them is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg44HttqmX4k1HxsUqZcYy)_