### PR TITLE
Release v0.7.0-alpha.2: New color spaces and display improvements

### DIFF
--- a/releases/v0.7.0-alpha.2.md
+++ b/releases/v0.7.0-alpha.2.md
@@ -5,5 +5,18 @@ The second pre-release of v0.7.0.
 ## New features
 
 - 🆕 **New color spaces** Gamut-relative OKLCh and LCH spaces, where `c = 1` is the most colorful in-gamut color at a given lightness and hue (so `c` reads as a 0–100% "how colorful for this gamut"): `oklch-p3`, `oklch-srgb`, `oklch-rec2020`, `lch-p3`, `lch-srgb`, `lch-rec2020`. Built on a new general `GamutRelativeColorSpace` class (by @LeaVerou in #736)
+- 🆕 **Smarter `display()` fallback** When a color isn't natively supported by the browser, `display()` now stays as close as possible to the original color: it walks up the base color space chain (closest first) and uses the first supported ancestor, preserving the color's gamut (e.g. an `hsl-p3` color falls back to `color(display-p3 …)` rather than `lab()`) instead of always jumping to the widest default. Adds an opt-in `displaySpaces` override on `ColorSpace`, a parameterizable `supports()`, and a `DisplayOptions` interface (by @LeaVerou in #738)
+- 🆕 **Expose transformation matrices via `ColorSpace.M`** Color spaces now expose the transformation matrices they use internally through a new `M` property, so consumers can reuse them instead of duplicating the data. Matrices for RGB spaces can also be supplied via the generic `M` option (by @LeaVerou in #749)
+- 🆕 **Matrix algebra utilities** Added `inv` (matrix inversion) and `solve` to the math utilities, so external libraries are no longer required when developing new color spaces (by @facelessuser)
+
+### Bug fixes & performance
+
+- Preserve a subclass's own `toBase`/`fromBase` when options omit them, instead of clobbering prototype methods with `undefined` (by @LeaVerou)
+
+### Build & distribution
+
+- Remove the pre-built ESM bundles and point the `.` export directly at the source. This also fixes a dual-instance problem where importing from `src/` vs. the package root could yield different `Color` registries (by @LeaVerou in #739)
+- Stop publishing the minified `.min.*` files from `dist/`; existing CDN links are transparently rewritten to the unminified equivalents (by @LeaVerou in #741)
+- Fix the CI install command after the lockfile removal (by @MysteryBlokHed in #744)
 
 **Full Changelog**: https://github.com/color-js/color.js/compare/v0.7.0-alpha.1...v0.7.0-alpha.2


### PR DESCRIPTION
## Summary

This release introduces gamut-relative color spaces, smarter color fallback handling, exposed transformation matrices, and matrix algebra utilities. It also includes distribution improvements and bug fixes.

## Key Changes

**New Features:**
- Added gamut-relative OKLCh and LCH color spaces (`oklch-p3`, `oklch-srgb`, `oklch-rec2020`, `lch-p3`, `lch-srgb`, `lch-rec2020`) with a new `GamutRelativeColorSpace` base class that maps chroma to 0–100% "colorfulness" for a given gamut
- Implemented smarter `display()` fallback logic that walks up the color space inheritance chain to find the closest supported ancestor, preserving gamut information instead of always falling back to the widest default
- Exposed transformation matrices via a new `ColorSpace.M` property, allowing consumers to reuse internal matrices and enabling matrix supply via generic `M` option for RGB spaces
- Added matrix algebra utilities (`inv` for inversion and `solve`) to reduce external dependencies when developing new color spaces

**Bug Fixes:**
- Fixed subclass `toBase`/`fromBase` methods being clobbered with `undefined` when options omit them, now properly preserves prototype methods

**Build & Distribution:**
- Removed pre-built ESM bundles and pointed the `.` export directly at source files, fixing dual-instance issues from importing via `src/` vs. package root
- Stopped publishing minified `.min.*` files; CDN links are transparently rewritten to unminified equivalents
- Fixed CI install command after lockfile removal

## Implementation Details

The `display()` improvements add an opt-in `displaySpaces` override on `ColorSpace` and a parameterizable `supports()` method, along with a new `DisplayOptions` interface for configuration.

https://claude.ai/code/session_01SYCiRbpPR8tanUcyKqAzqq