### PR TITLE
Update gamut surface threshold and document values for 32 bit vs 64 bit

### DIFF
--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -354,6 +354,7 @@ function raytrace_box (start, end, bmin = [0, 0, 0], bmax = [1, 1, 1]) {
 		direction.push(d);
 
 		// Non parallel cases
+		// 1e-12 for 64 bit unit types and 1e-6 for 32 bit unit types
 		if (Math.abs(d) > 1e-12) {
 			const inv_d = 1 / d;
 			const t1 = (bn - a) * inv_d;
@@ -466,8 +467,9 @@ export function toGamutRayTrace (origin, { space } = {}) {
 
 		// Calculate bounds to adjust the anchor closer to the gamut surface.
 		// We don't want to make the ray too short, so offset some amount from the low and high range.
-		const low = mn + 1e-6;
-		const high = mx - 1e-6;
+		// 1e-12 for 64 bit unit types and 1e-6 for 32 bit unit types.
+		const low = mn + 1e-12;
+		const high = mx - 1e-12;
 
 		// Cast a ray from the zero chroma color to the target color.
 		// Trace the line to the RGB cube edge and find where it intersects.


### PR DESCRIPTION
For 64-bit values, 1e-12 can give better resolution in some specific cases. 1e-6 is better for 32-bit values.

As far as the CSS spec is concerned, the stated value of 1e-6 is fine, assuming implementation with 32-bit values. A note is likely needed to clarify this, not only for the gamut surface distance threshold, but for the ray trace delta threshold, which we also updated the comment for in this PR.