### PR TITLE
Exclude hue angle from alpha premultiplication

### DIFF
--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -147,10 +147,14 @@ Color.range = function(color1, color2, options = {}) {
 		[color1[space.id].hue, color2[space.id].hue] = angles.adjust(arc, [color1[space.id].hue, color2[space.id].hue]);
 	}
 
+	// Find the hue coordinate (if any) so it's excluded from premultiplication:
+	// an angle must not be scaled by alpha.
+	let coordNames = Object.keys(space.coords);
+	let hueIndex = coordNames.findIndex(name => space.coords[name].isAngle);
+
 	if (premultiplied) {
-		// not coping with polar spaces yet
-		color1.coords = color1.coords.map (c => c * color1.alpha);
-		color2.coords = color2.coords.map (c => c * color2.alpha);
+		color1.coords = color1.coords.map((c, i) => i === hueIndex? c : c * color1.alpha);
+		color2.coords = color2.coords.map((c, i) => i === hueIndex? c : c * color2.alpha);
 	}
 
 	return Object.assign(p => {
@@ -163,8 +167,8 @@ Color.range = function(color1, color2, options = {}) {
 		let ret = new Color(space, coords, alpha);
 
 		if (premultiplied) {
-			// undo premultiplication
-			ret.coords = ret.coords.map(c => c / alpha);
+			// undo premultiplication, leaving the hue angle untouched
+			ret.coords = ret.coords.map((c, i) => i === hueIndex? c : c / alpha);
 		}
 
 		if (outputSpace !== space) {


### PR DESCRIPTION
## Summary

Alpha premultiplication in `Color.range()` multiplied **every** coordinate by alpha. That's correct for rectangular spaces but wrong for polar ones: a hue angle must not be scaled by alpha (the old code even carried a `// not coping with polar spaces yet` note).

This finds the hue coordinate via the `isAngle` flag every space already declares (`angles.range`) and excludes it from both the premultiply and undo steps. Rectangular spaces are unaffected — `findIndex` returns `-1`, which matches no coordinate index.

## Testing

Exercised the real `Color.range(...)` path under Node:

- **HSL, opaque `hsl(30 100% 50%)` → transparent `hsl(90 100% 50%)`, premultiplied** → hue = **60°** (a plain midpoint). The old code would have premultiplied the angle and produced a wrong **30°**.
- **sRGB, opaque red → transparent blue, premultiplied** → `[1, 0, 0]` (transparent endpoint contributes nothing) — unchanged.
- **sRGB, plain interpolation** → `[0.5, 0, 0.5]` — unchanged.
- No `NaN` leaked from the skip/divide logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)