### PR TITLE
Premultiply alpha correctly in polar spaces, and handle none/zero alpha

### DIFF
--- a/src/ColorSpace.js
+++ b/src/ColorSpace.js
@@ -159,14 +159,30 @@ export default class ColorSpace {
 		return this.formats?.color?.id || this.id;
 	}
 
-	get isPolar () {
+	/**
+	 * The id of this space's hue coordinate, or null if the space is not polar
+	 * @returns {string | null}
+	 */
+	get hueId () {
 		for (let id in this.coords) {
 			if (this.coords[id].type === "angle") {
-				return true;
+				return id;
 			}
 		}
 
-		return false;
+		return null;
+	}
+
+	/**
+	 * The index of this space's hue coordinate within its coords array, or -1 if the space is not polar
+	 * @returns {number}
+	 */
+	get hueIndex () {
+		return Object.keys(this.coords).findIndex(id => this.coords[id].type === "angle");
+	}
+
+	get isPolar () {
+		return this.hueId !== null;
 	}
 
 	/**

--- a/src/ColorSpace.js
+++ b/src/ColorSpace.js
@@ -495,7 +495,7 @@ export default class ColorSpace {
 function getPath (space) {
 	let ret = [space];
 
-	for (let s = space; (s = s.base); ) {
+	for (let s = space; (s = s.base);) {
 		ret.push(s);
 	}
 

--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -184,12 +184,16 @@ export function range (color1, color2, options = {}) {
 	color1 = toGamut(color1);
 	color2 = toGamut(color2);
 
+	// The hue coordinate is not always called "h" (e.g. it's "hz" in Jzczhz)
+	let hueId = space.hueId;
+	let hueIndex = space.hueIndex;
+
 	// Handle hue interpolation
 	// See https://github.com/w3c/csswg-drafts/issues/4735#issuecomment-635741840
-	if (space.coords.h && space.coords.h.type === "angle") {
+	if (hueId) {
 		let arc = (options.hue = options.hue || "shorter");
 
-		let /** @type {Ref} */ hue = [space, "h"];
+		let /** @type {Ref} */ hue = [space, hueId];
 		let [θ1, θ2] = [get(color1, hue), get(color2, hue)];
 		// Undefined hues must be evaluated before hue fix-up to properly
 		// calculate hue arcs between undefined and defined hues.
@@ -205,14 +209,20 @@ export function range (color1, color2, options = {}) {
 		set(color2, hue, θ2);
 	}
 
+	// An undefined alpha takes the other color's alpha, and premultiplication must use
+	// that carried forward value, rather than the zero it would otherwise be treated as.
+	// If both alphas are undefined, they stay that way, and no premultiplication happens.
+	// See https://drafts.csswg.org/css-color-4/#interpolation-missing
+	if (isNone(color1.alpha) && !isNone(color2.alpha)) {
+		color1.alpha = color2.alpha;
+	}
+	else if (isNone(color2.alpha) && !isNone(color1.alpha)) {
+		color2.alpha = color1.alpha;
+	}
+
 	if (premultiplied) {
-		// not coping with polar spaces yet
-		color1.coords = /** @type {[number, number, number]} */ (
-			color1.coords.map(c => c * color1.alpha)
-		);
-		color2.coords = /** @type {[number, number, number]} */ (
-			color2.coords.map(c => c * color2.alpha)
-		);
+		color1.coords = premultiply(color1.coords, color1.alpha, hueIndex);
+		color2.coords = premultiply(color2.coords, color2.alpha, hueIndex);
 	}
 
 	return Object.assign(
@@ -227,8 +237,8 @@ export function range (color1, color2, options = {}) {
 			let ret = { space, coords, alpha };
 
 			if (premultiplied) {
-				// undo premultiplication
-				ret.coords = ret.coords.map(c => c / alpha);
+				// Undo premultiplication, again leaving any hue angle untouched
+				ret.coords = premultiply(ret.coords, alpha, hueIndex, true);
 			}
 
 			if (outputSpace !== space) {
@@ -240,6 +250,35 @@ export function range (color1, color2, options = {}) {
 		{
 			rangeArgs,
 		},
+	);
+}
+
+/**
+ * Premultiply a color's coordinates by its alpha, or undo premultiplication by dividing by it.
+ * Per CSS Color 4, the hue angle of a polar space is never premultiplied,
+ * `none` components stay `none`, a `none` alpha means no (un)premultiplication happens at all,
+ * and un-premultiplying by a zero alpha leaves the coords as they are, rather than dividing by zero.
+ * See https://drafts.csswg.org/css-color-4/#interpolation-alpha
+ * @param {(number | null)[]} coords
+ * @param {number | null} alpha
+ * @param {number} hueIndex - Index of the hue coordinate, or -1 if the space has none
+ * @param {boolean} [undo=false] - Divide by alpha instead of multiplying by it
+ * @returns {[number, number, number]}
+ */
+function premultiply (coords, alpha, hueIndex, undo = false) {
+	if (isNone(alpha) || (undo && alpha === 0)) {
+		// The (un-)premultiplied value is the value itself
+		return /** @type {[number, number, number]} */ (coords);
+	}
+
+	return /** @type {[number, number, number]} */ (
+		coords.map((c, i) => {
+			if (i === hueIndex || isNone(c)) {
+				return c;
+			}
+
+			return undo ? c / alpha : c * alpha;
+		})
 	);
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -76,16 +76,20 @@ export function toPrecision (n, precision) {
 }
 
 /**
- * @param {number} start
- * @param {number} end
+ * Interpolate between two values, either of which may be a `none` value.
+ * A `none` endpoint is treated as having the other endpoint's value;
+ * if both are `none`, the result is `none` as well.
+ * @param {number | null} start
+ * @param {number | null} end
  * @param {number} p
+ * @returns {number | null}
  */
 export function interpolate (start, end, p) {
-	if (isNaN(start)) {
+	if (isNone(start) || isNaN(start)) {
 		return end;
 	}
 
-	if (isNaN(end)) {
+	if (isNone(end) || isNaN(end)) {
 		return start;
 	}
 

--- a/test/index.json
+++ b/test/index.json
@@ -5,6 +5,7 @@
 	"delta": "DeltaE",
 	"gamut": "Gamut mapping",
 	"in_gamut": "In gamut",
+	"interpolation": "Interpolation",
 	"modifications": "Color modification",
 	"contrast": "Contrast",
 	"angles": "Angles",

--- a/test/interpolation.js
+++ b/test/interpolation.js
@@ -139,7 +139,8 @@ export default {
 		},
 		{
 			name: "Premultiplied alpha in rectangular spaces",
-			description: "All coordinates are premultiplied, and zero alpha still must not divide by zero.",
+			description:
+				"All coordinates are premultiplied, and zero alpha still must not divide by zero.",
 			data: { options: { space: "srgb", premultiplied: true } },
 			tests: [
 				{
@@ -180,7 +181,11 @@ export default {
 				{
 					name: "One alpha missing, in Jzczhz",
 					data: { options: { space: "jzczhz", premultiplied: true } },
-					args: ["color(jzczhz 0.1 0.05 30 / none)", "color(jzczhz 0.05 0.02 90 / 0.4)", 0.5],
+					args: [
+						"color(jzczhz 0.1 0.05 30 / none)",
+						"color(jzczhz 0.05 0.02 90 / 0.4)",
+						0.5,
+					],
 					expect: [0.075, 0.035, 60, 0.4],
 				},
 			],
@@ -219,11 +224,7 @@ export default {
 					name: "Premultiplied Lab",
 					description: "Expected: lab(58.873% 51.552 7.108 / 0.5).",
 					data: { options: { space: "lab", premultiplied: true } },
-					args: [
-						"rgb(76% 62% 03% / 0.4)",
-						"color(display-p3 0.84 0.19 0.72 / 0.6)",
-						0.5,
-					],
+					args: ["rgb(76% 62% 03% / 0.4)", "color(display-p3 0.84 0.19 0.72 / 0.6)", 0.5],
 					expect: [58.873, 51.552, 7.108, 0.5],
 				},
 				{
@@ -232,11 +233,7 @@ export default {
 					The hue is 391.82 rather than 31.82 because hues are not normalized back into
 					[0, 360) after the shorter arc fix-up; 391.82 - 360 = 31.82.`,
 					data: { options: { space: "lch", premultiplied: true } },
-					args: [
-						"rgb(76% 62% 03% / 0.4)",
-						"color(display-p3 0.84 0.19 0.72 / 0.6)",
-						0.5,
-					],
+					args: ["rgb(76% 62% 03% / 0.4)", "color(display-p3 0.84 0.19 0.72 / 0.6)", 0.5],
 					expect: [58.873, 81.126, 391.82, 0.5],
 				},
 				{

--- a/test/interpolation.js
+++ b/test/interpolation.js
@@ -1,0 +1,255 @@
+import Color from "../src/index.js";
+import ColorSpace from "../src/ColorSpace.js";
+import * as check from "../node_modules/htest.dev/src/check.js";
+
+/**
+ * Compare [...coords, alpha], where any of them may be a missing component.
+ * Missing components are `null` in Color.js, and `check.proximity()` would happily match
+ * `null` against 0, since `Math.abs(null - 0)` is 0. Conflating the two is precisely the bug
+ * these tests guard against, so missing components are compared strictly instead.
+ * NaN fails `proximity()`, which is what we want: it is never a valid result.
+ * @param {{ epsilon?: number }} options
+ */
+function checkColor ({ epsilon = 0.0001 } = {}) {
+	let closeEnough = check.proximity({ epsilon });
+
+	return check.deep((actual, expect) => {
+		if (actual === null || expect === null) {
+			return actual === expect;
+		}
+
+		return closeEnough(actual, expect);
+	});
+}
+
+export default {
+	name: "Interpolation tests",
+	description: `These tests check hue arcs, premultiplied alpha, and missing components during interpolation.
+	Expected values are hand-derived from
+	<a href="https://drafts.csswg.org/css-color-4/#interpolation">CSS Color 4 § 13</a>,
+	or taken from the examples in the spec.
+	Colors are given in the interpolation space, so that conversion cannot obscure what is being tested.`,
+	run (color1, color2, p = 0.5) {
+		let color = Color.range(color1, color2, this.data.options)(p);
+		return [...color.coords, color.alpha];
+	},
+	check: checkColor(),
+	tests: [
+		{
+			name: "Hue coordinate lookup",
+			description: `Premultiplication needs to know which coordinate, if any, is a hue angle.
+			Note that it is not always called "h", nor is it always last.`,
+			run (id) {
+				let space = ColorSpace.get(id);
+				return [space.hueId, space.hueIndex, space.isPolar];
+			},
+			check: check.deep(),
+			tests: [
+				{
+					args: ["oklch"],
+					expect: ["h", 2, true],
+				},
+				{
+					name: "Jzczhz names its hue coordinate hz",
+					args: ["jzczhz"],
+					expect: ["hz", 2, true],
+				},
+				{
+					name: "HSL has its hue first, not last",
+					args: ["hsl"],
+					expect: ["h", 0, true],
+				},
+				{
+					args: ["hwb"],
+					expect: ["h", 0, true],
+				},
+				{
+					name: "Lab is not polar",
+					args: ["lab"],
+					expect: [null, -1, false],
+				},
+				{
+					name: "sRGB is not polar",
+					args: ["srgb"],
+					expect: [null, -1, false],
+				},
+			],
+		},
+		{
+			name: "Premultiplied alpha in polar spaces",
+			description: `The hue angle must not be premultiplied, only the other two coordinates.
+			Interpolating an opaque color with a fully transparent one therefore keeps the opaque color's
+			lightness and chroma throughout, while the hue is simply interpolated.`,
+			data: { options: { space: "oklch", premultiplied: true } },
+			tests: [
+				{
+					name: "Opaque endpoint is unchanged",
+					args: ["oklch(80% 0.2 30)", "oklch(40% 0.1 90 / 0)", 0],
+					expect: [0.8, 0.2, 30, 1],
+				},
+				{
+					name: "Midpoint keeps L and C of the opaque color, and averages the hue",
+					description: `Premultiplied, the transparent color contributes [0 0] to L and C,
+					so the midpoint is [0.4 0.1] / 0.5 = [0.8 0.2]. The hue is not premultiplied,
+					so it is (30 + 90) / 2 = 60, and not 60 / 0.5 = 120.`,
+					args: ["oklch(80% 0.2 30)", "oklch(40% 0.1 90 / 0)", 0.5],
+					expect: [0.8, 0.2, 60, 0.5],
+				},
+				{
+					name: "Zero alpha does not divide by zero",
+					description: `Un-premultiplying by an alpha of zero would produce NaN.
+					Per CSS Color 4, the un-premultiplied value is the premultiplied value instead.`,
+					args: ["oklch(80% 0.2 30)", "oklch(40% 0.1 90 / 0)", 1],
+					expect: [0, 0, 90, 0],
+				},
+				{
+					name: "Partial alphas, 0.8 and 0.2",
+					description: `Premultiplied, the endpoints are [0.64 0.16 30] and [0.08 0.02 90],
+					so the midpoint is [0.36 0.09 60], which un-premultiplies by 0.5 to [0.72 0.18 60].`,
+					args: ["oklch(80% 0.2 30 / 0.8)", "oklch(40% 0.1 90 / 0.2)", 0.5],
+					expect: [0.72, 0.18, 60, 0.5],
+				},
+				{
+					name: "Same colors, not premultiplied, for comparison",
+					data: { options: { space: "oklch" } },
+					args: ["oklch(80% 0.2 30 / 0.8)", "oklch(40% 0.1 90 / 0.2)", 0.5],
+					expect: [0.6, 0.15, 60, 0.5],
+				},
+				{
+					name: "HSL, whose hue is the first coordinate",
+					data: { options: { space: "hsl", premultiplied: true } },
+					args: ["hsl(0 100% 50%)", "hsl(60 50% 20% / 0)", 0.5],
+					expect: [30, 100, 50, 0.5],
+				},
+				{
+					name: "Jzczhz, whose hue is called hz",
+					data: { options: { space: "jzczhz", premultiplied: true } },
+					args: ["color(jzczhz 0.1 0.05 30)", "color(jzczhz 0.05 0.02 90 / 0)", 0.5],
+					expect: [0.1, 0.05, 60, 0.5],
+				},
+				{
+					name: "Jzczhz hue is fixed up along the shorter arc",
+					description: `Hues are not normalized back into [0, 360) after fix-up,
+					so the midpoint of the 350 → 380 arc is 365.`,
+					data: { options: { space: "jzczhz" } },
+					args: ["color(jzczhz 0.1 0.05 350)", "color(jzczhz 0.1 0.05 20)", 0.5],
+					expect: [0.1, 0.05, 365, 1],
+				},
+			],
+		},
+		{
+			name: "Premultiplied alpha in rectangular spaces",
+			description: "All coordinates are premultiplied, and zero alpha still must not divide by zero.",
+			data: { options: { space: "srgb", premultiplied: true } },
+			tests: [
+				{
+					name: "red to transparent stays red",
+					description: `"transparent" is rgba(0, 0, 0, 0), so without premultiplication
+					this would pass through gray. Premultiplied, it stays fully saturated red.`,
+					args: ["red", "transparent", 0.5],
+					expect: [1, 0, 0, 0.5],
+				},
+				{
+					name: "Zero alpha does not divide by zero",
+					args: ["red", "transparent", 1],
+					expect: [0, 0, 0, 0],
+				},
+			],
+		},
+		{
+			name: "Missing alpha",
+			description: `A missing component is treated as having the other color's value, and premultiplication
+			must use that carried forward value. If both alphas are missing, alpha stays missing and no
+			premultiplication happens at all.
+			See <a href="https://drafts.csswg.org/css-color-4/#interpolation-missing">CSS Color 4 § 13.2</a>.`,
+			data: { options: { space: "oklch", premultiplied: true } },
+			tests: [
+				{
+					name: "Both alphas missing: alpha stays missing, coords are not premultiplied",
+					args: ["oklch(80% 0.2 30 / none)", "oklch(40% 0.1 90 / none)", 0.5],
+					expect: [0.6, 0.15, 60, null],
+				},
+				{
+					name: "One alpha missing: carried forward from the other color",
+					description: `The missing alpha becomes 0.5, so both colors are premultiplied by 0.5,
+					which gives the same result as interpolating without premultiplication.
+					It must not be treated as zero, which would premultiply every coordinate to 0.`,
+					args: ["oklch(80% 0.2 30 / none)", "oklch(40% 0.1 90 / 0.5)", 0.5],
+					expect: [0.6, 0.15, 60, 0.5],
+				},
+				{
+					name: "One alpha missing, in Jzczhz",
+					data: { options: { space: "jzczhz", premultiplied: true } },
+					args: ["color(jzczhz 0.1 0.05 30 / none)", "color(jzczhz 0.05 0.02 90 / 0.4)", 0.5],
+					expect: [0.075, 0.035, 60, 0.4],
+				},
+			],
+		},
+		{
+			name: "Missing hue",
+			description: `A missing hue takes the other color's hue, so that the interpolation stays
+			on a single hue rather than sweeping towards 0deg.`,
+			data: { options: { space: "oklch" } },
+			tests: [
+				{
+					name: "CSS Color 4 example: oklch(39.2% 0.4 none) keeps the hue 326.5",
+					args: ["oklch(78.3% 0.108 326.5)", "oklch(39.2% 0.4 none)", 0.5],
+					expect: [0.5875, 0.254, 326.5, 1],
+				},
+			],
+		},
+		{
+			name: "CSS Color 4 examples",
+			description: `Worked examples from
+			<a href="https://drafts.csswg.org/css-color-4/#interpolation-alpha">CSS Color 4 § 13.3</a>.
+			The expected values are the ones given in the spec, which are computed from rounded
+			intermediate values, hence the looser epsilon.`,
+			check: checkColor({ epsilon: 0.02 }),
+			tests: [
+				{
+					name: "Premultiplied sRGB",
+					description: `rgb(24% 12% 98% / 0.4) and rgb(62% 26% 64% / 0.6) premultiply to
+					[9.6% 4.8% 39.2%] and [37.2% 15.6% 38.4%], whose midpoint [23.4% 10.2% 38.8%]
+					un-premultiplies to rgb(46.8% 20.4% 77.6% / 0.5).`,
+					data: { options: { space: "srgb", premultiplied: true } },
+					args: ["rgb(24% 12% 98% / 0.4)", "rgb(62% 26% 64% / 0.6)", 0.5],
+					expect: [0.468, 0.204, 0.776, 0.5],
+				},
+				{
+					name: "Premultiplied Lab",
+					description: "Expected: lab(58.873% 51.552 7.108 / 0.5).",
+					data: { options: { space: "lab", premultiplied: true } },
+					args: [
+						"rgb(76% 62% 03% / 0.4)",
+						"color(display-p3 0.84 0.19 0.72 / 0.6)",
+						0.5,
+					],
+					expect: [58.873, 51.552, 7.108, 0.5],
+				},
+				{
+					name: "Premultiplied LCH, where the hue is not premultiplied",
+					description: `Expected: lch(58.873% 81.126 31.82 / 0.5).
+					The hue is 391.82 rather than 31.82 because hues are not normalized back into
+					[0, 360) after the shorter arc fix-up; 391.82 - 360 = 31.82.`,
+					data: { options: { space: "lch", premultiplied: true } },
+					args: [
+						"rgb(76% 62% 03% / 0.4)",
+						"color(display-p3 0.84 0.19 0.72 / 0.6)",
+						0.5,
+					],
+					expect: [58.873, 81.126, 391.82, 0.5],
+				},
+				{
+					name: "Premultiplied Oklch, with a missing alpha carried forward",
+					description: `oklch(78.3% 0.108 326.5 / 0.5) and oklch(39.2% 0.4 0 / none):
+					the missing alpha becomes 0.5, giving the premultiplied values
+					[0.3915 0.054 326.5] and [0.196 0.2 360]. The spec's gradient for this example
+					has oklch(58.75% 0.254 343.25 / 0.5) at its midpoint.`,
+					data: { options: { space: "oklch", premultiplied: true } },
+					args: ["oklch(78.3% 0.108 326.5 / 0.5)", "oklch(39.2% 0.4 0 / none)", 0.5],
+					expect: [0.5875, 0.254, 343.25, 0.5],
+				},
+			],
+		},
+	],
+};


### PR DESCRIPTION
Premultiplication multiplied every coordinate by alpha, including the hue angle of polar spaces, which is meaningless. Per CSS Color 4 13.3, the hue angle is never premultiplied, and un-premultiplication must not divide by a zero or none alpha.

- Add ColorSpace#hueId and ColorSpace#hueIndex, so the hue coordinate is looked up from the space definition rather than assumed to be named h. isPolar is now expressed in terms of hueId.
- Skip the hue angle when premultiplying and when undoing premultiplication.
- Leave the coords untouched when undoing premultiplication with an alpha of zero, rather than dividing by zero and producing NaN.
- Carry a none alpha forward from the other color before premultiplying, per CSS Color 4 13.2, and leave alpha as none if both colors are missing it.
- Fix util.interpolate, which tested isNaN for missing components. none is null here, not NaN, so a none endpoint was coerced to 0 instead of taking the other endpoint's value. As a result, a none alpha used to premultiply every coordinate to zero, turning the color black.

Routing the hue lookup through hueId also fixes hue interpolation in Jzczhz, whose hue coordinate is named hz and so never matched the old check.