### PR TITLE
Mark CATs.js and space-accessors.js as side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,8 @@
 	},
 	"sideEffects": [
 		"./src/index.js",
-		"./src/spaces/index.js"
+		"./src/spaces/index.js",
+		"./src/CATs.js",
+		"./src/space-accessors.js"
 	]
 }


### PR DESCRIPTION
## Summary
Updated the `sideEffects` configuration in package.json to include two additional modules that have side effects and should not be tree-shaken during bundling.

## Changes
- Added `./src/CATs.js` to the sideEffects array
- Added `./src/space-accessors.js` to the sideEffects array

## Details
These modules are now explicitly marked as having side effects, ensuring they are preserved during the bundling process even if they appear to be unused. This is important for modules that perform initialization, registration, or other side-effect operations that are necessary for the library to function correctly, even if they don't export values that are directly imported elsewhere.

https://claude.ai/code/session_012E5ftjpvSsU4xq4JiHTmdx