### PR TITLE
Enable the disabled chromatic adaptation tests

### DIFF
--- a/test/adapt.js
+++ b/test/adapt.js
@@ -1,3 +1,8 @@
+// The expected matrices here are computed at full double precision from the
+// whitepoints and cone matrices in src/, rather than taken from Lindbloom's
+// published tables. Lindbloom rounds to 7 decimals and uses slightly different
+// D50/D65 definitions, which is why these tests were previously commented out:
+// they cannot pass at a tolerance tight enough to catch a regression. See #397.
 import { WHITES } from "../src/adapt.js";
 import { adapt } from "../src/CATs.js";
 
@@ -7,7 +12,9 @@ export default {
 	name: "Chromatic adaptation tests",
 	description: "These tests adapt from one whitepoint to another.",
 	run: adapt,
-	check: check.deep(check.proximity({ epsilon: 0.00005 })),
+	// The expected matrices below are exact to double precision, so the tolerance
+	// only needs to absorb floating-point ordering differences.
+	check: check.deep(check.proximity({ epsilon: 1e-13 })),
 	tests: [
 		{
 			name: "Bradford D50 ⇔ D65",
@@ -34,129 +41,133 @@ export default {
 				},
 			],
 		},
-		// ,
-		// {
-		// 	name: "Bradford Other whitepoints",
-		// 	description: `These test the linear Bradford adaptations from CATs.js against the matrices <a href="http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html">published by Lindbloom</a>`,
-		// 	tests: [
-		// 		{
-		// 			name: "C to D50",
-		// 			args: [WHITES.C, WHITES.D50, "Bradford"],
-		// 			expect: [
-		// 				[ 1.0376976,  0.0153932, -0.0582624],
-		// 				[ 0.0170675,  1.0056038, -0.0188973],
-		// 				[-0.0120126,  0.0204361,  0.6906380]
-		// 			],
-		// 		},
-		// 		{
-		// 			name: "A to C",
-		// 			args: [WHITES.A, WHITES.C, "Bradford"],
-		// 			expect: [
-		// 				[ 0.8530161, -0.1130268,  0.4404346],
-		// 				[-0.1238786,  1.0853435,  0.1425803],
-		// 				[ 0.0911907, -0.1553658,  3.4776250]
-		// 			]
-		// 		},
-		// 		{
-		// 			name: "F2 to D50",
-		// 			args: [WHITES.F2, WHITES.D50, "Bradford"],
-		// 			expect: [
-		// 				[ 0.9628262, -0.0215790,  0.0457172],
-		// 				[-0.0280310,  1.0172847,  0.0156071],
-		// 				[ 0.0083415, -0.0135344,  1.2322804]
-		// 			]
-		// 		},
-		// 	]
-		// },
-		// {
-		// 	name: "von Kries Other whitepoints",
-		// 	description: `These test the von Kries adaptations from CATs.js against the matrices <a href="http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html">published by Lindbloom</a>.`,
-		// 	tests: [
-		// 		{
-		// 			name: "C to D50",
-		// 			args: [WHITES.C, WHITES.D50, "von Kries"],
-		// 			expect: [
-		// 				[ 1.0132609,  0.0457455, -0.0636638],
-		// 				[ 0.0050248,  0.9962695, -0.0010128],
-		// 				[ 0.0000000,  0.0000000,  0.6979583]
-		// 			],
-		// 		},
-		// 		{
-		// 			name: "A to C",
-		// 			args: [WHITES.A, WHITES.C, "von Kries"],
-		// 			expect: [
-		// 				[ 0.9418277, -0.2249131,  0.4806950],
-		// 				[-0.0247051,  1.0253682,  0.0049749],
-		// 				[ 0.0000000,  0.0000000,  3.3225235]
-		// 			]
-		// 		},
-		// 		{
-		// 			name: "F2 to D50",
-		// 			args: [WHITES.F2, WHITES.D50, "von Kries"],
-		// 			expect: [
-		// 				[ 0.9869554, -0.0470220,  0.0479582],
-		// 				[-0.0051650,  1.0044210,  0.0010416],
-		// 				[ 0.0000000,  0.0000000,  1.2244744]
-		// 			]
-		// 		},
-		// 	]
-		// },
-		// {
-		// 	name: "CAT02 and CAT16, D50 ⇔ D65",
-		// 	description: "These test the fully adapted CAT02 and CAT16 adaptations from CATs.js, interconverting between D50 and D65.",
-		// 	tests: [
-		// 		{
-		// 			name: "CAT02 D50 to D65",
-		// 			args: [WHITES.D50, WHITES.D65, "CAT02"],
-		// 			expect: [
-		// 				[ 0.9599435, -0.0292880,  0.0656334],
-		// 				[-0.0211745,  0.9988615,  0.0261212],
-		// 				[ 0.0013700,  0.0044344,  1.3124836]
-		// 			]
-		// 		},
-		// 		{
-		// 			name: "CAT02 D65 to D50",
-		// 			args: [WHITES.D65, WHITES.D50, "CAT02"],
-		// 			expect: [
-		// 				[ 1.0424827,  0.0308012, -0.0527444],
-		// 				[ 0.0221295,  1.0018823, -0.0210462],
-		// 				[-0.0011630, -0.0034170,  0.7620404]
-		// 			]
-		// 		},
-		// 		{
-		// 			name: "CAT16 D50 to D65",
-		// 			args: [WHITES.D50, WHITES.D65, "CAT16"],
-		// 			expect: [
-		// 				[ 0.9894962, -0.0399233,  0.0439904],
-		// 				[-0.0053910,  1.0066456, -0.0017541],
-		// 				[-0.0004037,  0.0150564,  1.3016843]
-		// 			]
-		// 		},
-		// 		{
-		// 			name: "CAT16 D65 to D50",
-		// 			args: [WHITES.D65, WHITES.D50, "CAT16"],
-		// 			expect: [
-		// 				[ 1.0108226,  0.0405991, -0.0341060],
-		// 				[ 0.0054139,  0.99359563, 0.0011560],
-		// 				[ 0.0002508, -0.01148016, 0.7682115]
-		// 			]
-		// 		},
-		// 	]
-		// },
-		// {
-		// 	name: "CAT16, C to D50",
-		// 	description: "This tests the fully adapted CAT16 adaptation from CATs.js, Illuminant C to D50.",
-		// 	tests: [
-		// 		{
-		// 			name: "CAT02 D50 to D65",
-		// 			args: [WHITES.C, WHITES.D50, "CAT16"],
-		// 			expect: [
-		// 				[ 1.0059635,  0.0270676, -0.0418130],
-		// 				[ 0.0037323,  0.9940963,  0.0018973],
-		// 				[ 0.0004538, -0.0145289,  0.7098704]
-		// 			]
-		// 		}
-		// 	]
-		// }
+		{
+			name: "Bradford, other whitepoints",
+			description: `These test the linear Bradford adaptations from CATs.js between whitepoints
+			other than D50 and D65.`,
+			tests: [
+				{
+					name: "C to D50",
+					args: [WHITES.C, WHITES.D50, "Bradford"],
+					expect: [
+						[1.0377690616813835, 0.015432491863571384, -0.05829085610275015],
+						[0.01712483023265995, 1.005561608870075, -0.018909106563750968],
+						[-0.012014886977626546, 0.02043774049861692, 0.6905493794119026],
+					],
+				},
+				{
+					name: "A to C",
+					args: [WHITES.A, WHITES.C, "Bradford"],
+					expect: [
+						[0.8530161029377393, -0.11302684514446544, 0.44043461027781017],
+						[-0.1238786267164161, 1.085343482281527, 0.1425802702443609],
+						[0.09119066102089231, -0.15536578576744575, 3.4776249673626407],
+					],
+				},
+				{
+					name: "F2 to D50",
+					args: [WHITES.F2, WHITES.D50, "Bradford"],
+					expect: [
+						[0.9628901155936045, -0.021540547893197686, 0.04567838539624731],
+						[-0.027976170151558757, 1.0172403858565684, 0.015592210273999952],
+						[0.008336759449053958, -0.013528177762873878, 1.2321218554541207],
+					],
+				},
+			],
+		},
+		{
+			name: "von Kries, other whitepoints",
+			description: `These test the von Kries adaptations from CATs.js between whitepoints other
+			than D50 and D65. The third row is exactly zero outside the diagonal because the von Kries
+			cone matrix has no cross-terms in its third row.`,
+			tests: [
+				{
+					name: "C to D50",
+					args: [WHITES.C, WHITES.D50, "von Kries"],
+					expect: [
+						[1.0132840543618833, 0.0458252820865854, -0.06368648854108123],
+						[0.00503358221481348, 0.996262953823303, -0.0010146062357561762],
+						[0, 0, 0.6978691069342143],
+					],
+				},
+				{
+					name: "A to C",
+					args: [WHITES.A, WHITES.C, "von Kries"],
+					expect: [
+						[0.9418277287171762, -0.22491306586053403, 0.48069497222064267],
+						[-0.02470510505654172, 1.0253682489745108, 0.004974874048335714],
+						[0, 0, 3.3225235351974147],
+					],
+				},
+				{
+					name: "F2 to D50",
+					args: [WHITES.F2, WHITES.D50, "von Kries"],
+					expect: [
+						[0.9869771433923064, -0.04694368550446698, 0.047922206295819544],
+						[-0.005156430897830803, 1.0044136577843679, 0.0010398702624227812],
+						[0, 0, 1.2243179595958933],
+					],
+				},
+			],
+		},
+		{
+			name: "CAT02 and CAT16, D50 ⇔ D65",
+			description:
+				"These test the fully adapted CAT02 and CAT16 adaptations from CATs.js, interconverting between D50 and D65.",
+			tests: [
+				{
+					name: "CAT02 D50 to D65",
+					args: [WHITES.D50, WHITES.D65, "CAT02"],
+					expect: [
+						[0.9598633148037599, -0.029371839290647215, 0.06573193477370372],
+						[-0.021234333154949502, 0.9988908612350015, 0.026160700537248418],
+						[0.0013724179601714644, 0.004440230349984853, 1.3129172960720608],
+					],
+				},
+				{
+					name: "CAT02 D65 to D50",
+					args: [WHITES.D65, WHITES.D50, "CAT02"],
+					expect: [
+						[1.0425738924111991, 0.030891075263705114, -0.0528125659319374],
+						[0.022193451065252008, 1.0018566328072378, -0.021073749209281616],
+						[-0.0011648800532352013, -0.003420527482775093, 0.7617890755244796],
+					],
+				},
+				{
+					name: "CAT16 D50 to D65",
+					args: [WHITES.D50, WHITES.D65, "CAT16"],
+					expect: [
+						[0.9894662537599116, -0.04003046264325008, 0.044053031713413716],
+						[-0.005405187332525404, 1.006660686033583, -0.0017555195476181061],
+						[-0.00040392099210183037, 0.015076802986294607, 1.302102113805948],
+					],
+				},
+				{
+					name: "CAT16 D65 to D50",
+					args: [WHITES.D65, WHITES.D50, "CAT16"],
+					expect: [
+						[1.010854328937934, 0.04070861032350117, -0.03414458250068625],
+						[0.005428142012307945, 0.9935819261930647, 0.0011559203885933907],
+						[0.0002507224681170432, -0.011491875891322783, 0.7679649469115445],
+					],
+				},
+			],
+		},
+		{
+			name: "CAT16, C to D50",
+			description:
+				"This tests the fully adapted CAT16 adaptation from CATs.js, Illuminant C to D50.",
+			tests: [
+				{
+					name: "CAT16 C to D50",
+					args: [WHITES.C, WHITES.D50, "CAT16"],
+					expect: [
+						[1.0059848431095035, 0.027139669944084323, -0.04182756660272263],
+						[0.0037416075974804224, 0.9940879775381585, 0.0018966762185267704],
+						[0.0004535060219078323, -0.014532752280760022, 0.7097846465384112],
+					],
+				},
+			],
+		},
 	],
 };


### PR DESCRIPTION
Closes https://github.com/color-js/color.js/issues/397.

### Background

The 11 commented-out sub-tests in test/adapt.js take their expected values from [Lindbloom's published tables](http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html). As @svgeesus mentioned in [this thread](https://github.com/color-js/color.js/issues/397#issuecomment-1926080340), those are rounded to 7 decimals and computed from slightly different D50/D65 definitions, so they can't pass at a tolerance tight enough to be a useful regression test. Lindbloom's C→D50 Bradford matrix differs from what CATs.js computes by 7.1e-05, outside the suite's 5e-05 epsilon, which is why they were commented out rather than fixed.

### What this PR does

This recalculates those values at higher precision and uses those as the expected values, as @svgeesus suggested in that thread.

Every value was computed two independent ways, neither of which uses CATs.js's own arithmetic:

- The von Kries formula, written from scratch in Python/numpy, fed the whitepoints in src/adapt.js and the cone matrices in src/CATs.js.

- [colour-science](https://www.colour-science.org/)'s matrix_chromatic_adaptation_VonKries, given the same whitepoints.

The two agree to 2.7e-16 (worst case) across all 13 cases.

### The result

The suite epsilon goes from 5e-05 to 1e-13. The worst disagreement between these values and what CATs.js computes is 4.4e-16 — one ulp on the largest element — so 1e-13 sits ~225× above the noise floor while being ~5e+08× tighter than before. If we want to loosen that, 1e-12 would work as well.

Also fixes a name inherited from the old suite: the CAT16 C→D50 test was called "CAT02 D50 to D65", copy-pasted down from a preceding group. The two previously-enabled tests keep their values, which already agree with the recomputation to 2.2e-16.

npm test: 794/866 passing, 72 skipped — up from 783/855, i.e. the 11 newly enabled tests and nothing else.

(Drafted with the help of Claude.)