### PR TITLE
[spaces/xyy] Add CIE xyY color space

### DIFF
--- a/src/space-coord-accessors.d.ts
+++ b/src/space-coord-accessors.d.ts
@@ -52,10 +52,12 @@ declare class SpaceAccessors {
 	rec2100pq: SpaceAccessor;
 	srgb: SpaceAccessor;
 	srgb_linear: SpaceAccessor;
+	xyy: SpaceAccessor;
 	xyz: SpaceAccessor;
 	xyz_abs_d65: SpaceAccessor;
 	xyz_d50: SpaceAccessor;
 	xyz_d65: SpaceAccessor;
+	Y: number | null;
 	a: number | null;
 	az: number | null;
 	b: number | null;

--- a/src/spaces/index-fn.js
+++ b/src/spaces/index-fn.js
@@ -5,6 +5,7 @@
 export { default as XYZ_D65 } from "./xyz-d65.js";
 export { default as XYZ_D50 } from "./xyz-d50.js";
 export { default as XYZ_ABS_D65 } from "./xyz-abs-d65.js";
+export { default as xyY } from "./xyy.js";
 export { default as Lab_D65 } from "./lab-d65.js";
 export { default as Lab } from "./lab.js";
 export { default as LCH } from "./lch.js";

--- a/src/spaces/xyy.js
+++ b/src/spaces/xyy.js
@@ -1,0 +1,65 @@
+import ColorSpace from "../ColorSpace.js";
+import { isNone, skipNone } from "../util.js";
+import XYZ_D65 from "./xyz-d65.js";
+
+/**
+ * CIE 1931 xyY separates chromaticity (x, y) from luminance (Y).
+ */
+export default new ColorSpace({
+	id: "xyy",
+	name: "xyY",
+	coords: {
+		x: {
+			refRange: [0, 1],
+			name: "x",
+		},
+		y: {
+			refRange: [0, 1],
+			name: "y",
+		},
+		Y: {
+			refRange: [0, 1],
+			name: "Y",
+		},
+	},
+
+	base: XYZ_D65,
+
+	// Convert D65-adapted XYZ to CIE 1931 xyY.
+	fromBase (XYZ) {
+		let [X, Y, Z] = XYZ.map(skipNone);
+		let sum = X + Y + Z;
+
+		// Chromaticity is undefined for black, so use the origin.
+		if (sum === 0) {
+			return [0, 0, Y];
+		}
+
+		return [X / sum, Y / sum, Y];
+	},
+
+	// Convert CIE 1931 xyY to D65-adapted XYZ.
+	toBase (xyY) {
+		let [x, y, Y] = xyY;
+
+		// A zero or missing y cannot define a finite chromaticity ratio.
+		if (y === 0 || isNone(y)) {
+			return [0, 0, 0];
+		}
+
+		x = skipNone(x);
+		Y = skipNone(Y);
+		return [(x * Y) / y, Y, ((1 - x - y) * Y) / y];
+	},
+
+	formats: {
+		color: {
+			ids: ["xyy"],
+			coords: [
+				"<number> | <percentage>",
+				"<number> | <percentage>",
+				"<number> | <percentage>",
+			],
+		},
+	},
+});

--- a/src/spaces/xyy.js
+++ b/src/spaces/xyy.js
@@ -1,6 +1,11 @@
 import ColorSpace from "../ColorSpace.js";
+import { getWhite } from "../adapt.js";
 import { isNone, skipNone } from "../util.js";
 import XYZ_D65 from "./xyz-d65.js";
+
+const D65 = getWhite(XYZ_D65.white);
+const D65_SUM = D65[0] + D65[1] + D65[2];
+const D65_CHROMATICITY = [D65[0] / D65_SUM, D65[1] / D65_SUM];
 
 /**
  * CIE 1931 xyY separates chromaticity (x, y) from luminance (Y).
@@ -30,9 +35,9 @@ export default new ColorSpace({
 		let [X, Y, Z] = XYZ.map(skipNone);
 		let sum = X + Y + Z;
 
-		// Chromaticity is undefined for black, so use the origin.
+		// Chromaticity is undefined for black, so use the reference white point.
 		if (sum === 0) {
-			return [0, 0, Y];
+			return [...D65_CHROMATICITY, Y];
 		}
 
 		return [X / sum, Y / sum, Y];

--- a/test/xyy.js
+++ b/test/xyy.js
@@ -1,0 +1,32 @@
+import Color from "../src/index.js";
+import * as check from "../node_modules/htest.dev/src/check.js";
+
+const tests = {
+	name: "xyY color space",
+	check: check.deep((actual, expect) =>
+		check.shallowEquals({ epsilon: 0.000001, subset: true })(actual, expect)),
+	tests: [
+		{
+			name: "D65 white has the reference chromaticity",
+			run: () => new Color("white").to("xyy").coords,
+			expect: [0.3127, 0.329, 1],
+		},
+		{
+			name: "xyY converts back to XYZ",
+			run: () => new Color("xyy", [0.3127, 0.329, 1]).to("xyz-d65").coords,
+			expect: [0.9504559270516717, 1, 1.0890577507598784],
+		},
+		{
+			name: "xyY parses through the color() syntax",
+			run: () => new Color("color(xyy 0.3127 0.329 1)").coords,
+			expect: [0.3127, 0.329, 1],
+		},
+		{
+			name: "black uses the chromaticity origin",
+			run: () => new Color("black").to("xyy").coords,
+			expect: [0, 0, 0],
+		},
+	],
+};
+
+export default tests;

--- a/test/xyy.js
+++ b/test/xyy.js
@@ -22,9 +22,9 @@ const tests = {
 			expect: [0.3127, 0.329, 1],
 		},
 		{
-			name: "black uses the chromaticity origin",
+			name: "black uses the D65 white point chromaticity",
 			run: () => new Color("black").to("xyy").coords,
-			expect: [0, 0, 0],
+			expect: [0.3127, 0.329, 0],
 		},
 	],
 };


### PR DESCRIPTION
## What changed

Closes #724.

- Added the CIE 1931 `xyY` color space with D65 XYZ as its base.
- Added the standard XYZ to xyY and xyY to XYZ conversions, including a black-color guard where chromaticity is undefined.
- Registered the space in the built-in space index and generated coordinate accessors.
- Added tests for D65 white, XYZ round-tripping, black, and `color(xyy ...)` parsing.

## Verification

- `npm test` passes: 787/859 passed, 72 skipped.
- `npx htest ./test/xyy.js` passes: 4/4.
- ESLint passes for the changed JavaScript files.
- `git diff --check` passes.

This contribution was prepared with AI assistance and reviewed and tested locally. The commit includes the required co-author trailer.