### PR TITLE
Further improve HCT conversion

### DIFF
--- a/src/spaces/hct.js
+++ b/src/spaces/hct.js
@@ -35,7 +35,6 @@ function fromHct (coords, env) {
 
 	let [h, c, t] = coords;
 	let xyz = [];
-	let j = 0;
 
 	// Shortcut out for black
 	if (t === 0) {
@@ -47,12 +46,8 @@ function fromHct (coords, env) {
 
 	// A better initial guess yields better results. Polynomials come from
 	// curve fitting the T vs J response.
-	if (t > 0) {
-		j = 0.00379058511492914 * t ** 2 + 0.608983189401032 * t + 0.9155088574762233;
-	}
-	else {
-		j = 9.514440756550361e-6 * t ** 2 + 0.08693057439788597 * t - 21.928975842194614;
-	}
+	const [wx, wy] = white;
+	let j = toCam16([(wx * y) / wy, y, ((1.0 - wx - wy) * y) / wy], env).J;
 
 	// Threshold of how close is close enough, and max number of attempts.
 	// More precision and more attempts means more time spent iterating. Higher
@@ -90,12 +85,11 @@ function fromHct (coords, env) {
 
 		// Newton: 2nd Order convergence
 		// First derivative approximation of J'
-		// Invert so we can multiply instead of divide
-		const jp = xyz[1] ? j / (α * xyz[1]) : 0;
+		const jp = j ? (α * xyz[1]) / j : 0;
 		if (Math.abs(jp) < epsilon) {
 			break;
 		}
-		j -= dy * jp;
+		j -= dy / jp;
 
 		// Ostrowski: 4th order convergence
 		if (jp) {
@@ -103,7 +97,7 @@ function fromHct (coords, env) {
 			const dy2 = xyz2[1] - y;
 			const denom = dy - 2 * dy2;
 			if (Math.abs(denom) >= epsilon) {
-				j -= (dy / denom) * (dy2 * jp);
+				j -= (dy / denom) * (dy2 / jp);
 			}
 		}
 

--- a/src/spaces/hct.js
+++ b/src/spaces/hct.js
@@ -79,11 +79,11 @@ function fromHct (coords, env) {
 				return xyz;
 			}
 
-            // If we are closer than last time, save the values.
-            // This is to ensure we take the best value when
-            // iterations are struggling to find a good value,
-            // e.g. Prophoto RGB in the blue region which is outside
-            // the visible spectrum and the CAM16 algorithm breaks down.
+			// If we are closer than last time, save the values.
+			// This is to ensure we take the best value when
+			// iterations are struggling to find a good value,
+			// e.g. Prophoto RGB in the blue region which is outside
+			// the visible spectrum and the CAM16 algorithm breaks down.
 			best = xyz;
 			last = delta;
 		}
@@ -91,7 +91,7 @@ function fromHct (coords, env) {
 		// Newton: 2nd Order convergence
 		// First derivative approximation of J'
 		// Invert so we can multiply instead of divide
-		const jp = (xyz[1]) ? j / (α * xyz[1]) : 0;
+		const jp = xyz[1] ? j / (α * xyz[1]) : 0;
 		if (Math.abs(jp) < epsilon) {
 			break;
 		}
@@ -99,18 +99,18 @@ function fromHct (coords, env) {
 
 		// Ostrowski: 4th order convergence
 		if (jp) {
-            const xyz2 = fromCam16({ J: j, C: c, h: h }, env);
-            const dy2 = xyz2[1] - y;
-            const denom = dy - 2 * dy2;
-            if (Math.abs(denom) >= epsilon) {
-            	j -= dy / denom * (dy2 * jp);
-            }
-        }
+			const xyz2 = fromCam16({ J: j, C: c, h: h }, env);
+			const dy2 = xyz2[1] - y;
+			const denom = dy - 2 * dy2;
+			if (Math.abs(denom) >= epsilon) {
+				j -= (dy / denom) * (dy2 * jp);
+			}
+		}
 
-        // Quit if there has been little to no change
-        if (Math.abs(j - prev) < epsilon) {
-        	break;
-        }
+		// Quit if there has been little to no change
+		if (Math.abs(j - prev) < epsilon) {
+			break;
+		}
 	}
 
 	// We could not acquire the precision we desired,

--- a/src/spaces/hct.js
+++ b/src/spaces/hct.js
@@ -7,6 +7,9 @@ import { WHITES } from "../adapt.js";
 const white = WHITES.D65;
 const ε = 216 / 24389; // 6^3/29^3 == (24/116)^3
 const κ = 24389 / 27; // 29^3/3^3
+// Average constant for the approximation of the first derivative: α * y / j
+// α is calculated average so that it is optimized for the majority of the cases.
+const α = 1.832;
 
 function toLstar (y) {
 	// Convert XYZ Y to L*
@@ -54,38 +57,60 @@ function fromHct (coords, env) {
 	// Threshold of how close is close enough, and max number of attempts.
 	// More precision and more attempts means more time spent iterating. Higher
 	// required precision gives more accuracy but also increases the chance of
-	// not hitting the goal. 2e-12 allows us to convert round trip with
-	// reasonable accuracy of six decimal places or more.
-	const threshold = 2e-12;
-	const max_attempts = 15;
+	// not hitting the goal.
+	const epsilon = 1e-12;
+	const max_attempts = 8;
 
 	let attempt = 0;
 	let last = Infinity;
 	let best = [0, 0, 0];
 
 	// Try to find a J such that the returned y matches the returned y of the L*
-	while (attempt <= max_attempts) {
+	while (attempt < max_attempts) {
+		attempt += 1;
+		const prev = j;
 		xyz = fromCam16({ J: j, C: c, h: h }, env);
 
-		// If we are within range, return XYZ
-		// If we are closer than last time, save the values
-		const delta = Math.abs(xyz[1] - y);
+		const dy = xyz[1] - y;
+		const delta = Math.abs(dy);
 		if (delta < last) {
-			if (delta <= threshold) {
+			// If we are within range, return XYZ
+			if (delta < epsilon) {
 				return xyz;
 			}
+
+            // If we are closer than last time, save the values.
+            // This is to ensure we take the best value when
+            // iterations are struggling to find a good value,
+            // e.g. Prophoto RGB in the blue region which is outside
+            // the visible spectrum and the CAM16 algorithm breaks down.
 			best = xyz;
 			last = delta;
 		}
 
-		// f(j_root) = (j ** (1 / 2)) * 0.1
-		// f(j) = ((f(j_root) * 100) ** 2) / j - 1 = 0
-		// f(j_root) = Y = y / 100
-		// f(j) = (y ** 2) / j - 1
-		// f'(j) = (2 * y) / j
-		j = j - ((xyz[1] - y) * j) / (2 * xyz[1]);
+		// Newton: 2nd Order convergence
+		// First derivative approximation of J'
+		// Invert so we can multiply instead of divide
+		const jp = (xyz[1]) ? j / (α * xyz[1]) : 0;
+		if (Math.abs(jp) < epsilon) {
+			break;
+		}
+		j -= dy * jp;
 
-		attempt += 1;
+		// Ostrowski: 4th order convergence
+		if (jp) {
+            const xyz2 = fromCam16({ J: j, C: c, h: h }, env);
+            const dy2 = xyz2[1] - y;
+            const denom = dy - 2 * dy2;
+            if (Math.abs(denom) >= epsilon) {
+            	j -= dy / denom * (dy2 * jp);
+            }
+        }
+
+        // Quit if there has been little to no change
+        if (Math.abs(j - prev) < epsilon) {
+        	break;
+        }
 	}
 
 	// We could not acquire the precision we desired,


### PR DESCRIPTION
1. Use an actually measured parameter that has been optimized for the majority of values in HCT. 1.832 allows faster and more precise convergence eliminating many cases were we in the past could not reach the target epsilon of 1e-12.
2. Employ Ostrowski's method to refine the Newton correction step ensuring max number of calls to `fromCam16` remains the same and cut the max number of iterations in half. In practice, we actually call `fromCam16` less on average increasing performance as well as further ensuring we consistently reach or exceed the target epsilon of 1e-12.
3. If derivative is too close to zero or the change between J and the corrected J is too small, exit the loop and return the best result we found so far.
4. Loop iteration adjusted from <= to < allowing us to specify the number of loops instead of the number of loops - 1.
5. Drop using the T -> J polynomial and just use the direct conversion of T -> Y and use that Y in a gray scale XYZ to CAM16 conversion to estimate the intial J

In short this gives us overall faster and more precise convergence. While the max iterations are cut in half, the max number of calls to `fromCam16` in the worse case are still the same. Worst cases usually manifest outside the visible spectrum, e.g. ProPhoto RGB in the blue region, etc.