### PR TITLE
[parse] Reject unexpected punctuation in color function arguments

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -266,6 +266,11 @@ export function parseFunction (str) {
 			return "";
 		});
 
+		// Argument matching must not silently discard unexpected punctuation.
+		if (/[^,\s]/.test(separators)) {
+			return;
+		}
+
 		return {
 			name,
 			args,

--- a/test/gamut.js
+++ b/test/gamut.js
@@ -273,7 +273,7 @@ export default {
 				},
 				{
 					args: ["color(display-p3 0 1 1)"],
-					expect: "rgb(0% 76.098% 75.455%))",
+					expect: "rgb(0% 76.098% 75.455%)",
 				},
 				{
 					args: ["color(display-p3 1 0 1)"],

--- a/test/parse.js
+++ b/test/parse.js
@@ -11,6 +11,56 @@ const tests = {
 	run: parse,
 	tests: [
 		{
+			name: "Unexpected function argument separators (#614)",
+			throws: TypeError,
+			tests: [
+				{ arg: "color(--lchuv 86.8% 42.9)230)" },
+				{ arg: "color(--lchuv 86.8{[]}(#!42.9 230)" },
+				...[
+					"!",
+					"@",
+					"#",
+					"$",
+					"^",
+					"&",
+					"*",
+					"[",
+					"]",
+					"{",
+					"}",
+					"(",
+					")",
+					"=",
+					";",
+					":",
+				].map(separator => ({
+					arg: `rgb(0${separator} 0 0)`,
+				})),
+				{ arg: "rgb(0 0 0 /)" },
+			],
+		},
+		{
+			name: "Valid separators and numeric tokens",
+			tests: [
+				{
+					arg: "color(--lchuv 86.8% 42.9 230 / 50%)",
+					expect: { spaceId: "lchuv", coords: [86.8, 42.9, 230], alpha: 0.5 },
+				},
+				{
+					arg: "rgb(0, 127.5, 255, 0.5)",
+					expect: { spaceId: "srgb", coords: [0, 0.5, 1], alpha: 0.5 },
+				},
+				{
+					arg: "color(srgb +1e-1\t.2 3e-1 / none)",
+					expect: { spaceId: "srgb", coords: [0.1, 0.2, 0.3], alpha: null },
+				},
+				{
+					arg: "lch(50 20 calc(NaN) / .5)",
+					expect: { spaceId: "lch", coords: [50, 20, NaN], alpha: 0.5 },
+				},
+			],
+		},
+		{
 			name: "none values",
 			tests: [
 				{


### PR DESCRIPTION
Fixes #614.

`color(--lchuv 86.8% 42.9)230)` currently parses successfully because argument extraction silently discards unmatched punctuation. Reject the function when unmatched content contains anything other than commas or whitespace.

Adds 19 invalid-input regressions and four valid-input controls, including alpha, scientific notation, `none`, and `calc(NaN)`. Also removes an extra closing parenthesis in an existing gamut test's expected value, exposed by the stricter parser. This change is limited to unconsumed punctuation; it does not attempt full CSS grammar validation.

Validation on base `19eb89f8995d2139436b6d38c7042944bb23a718`:
- All 19 new rejection cases fail before the source fix and pass afterward.
- Full suite: 817 passed, 72 existing skipped, zero failures.
- Full build, changed-file ESLint, parser/test formatting and diff whitespace checks pass. The gamut file retains an unrelated pre-existing formatting warning.

Prepared with OpenAI Codex assistance using GPT-6 Astra (`gpt-6-astra`), medium reasoning. I review all contributions before submission and remain responsible for the code and this message. The commit includes Codex co-author attribution.
